### PR TITLE
#28 Feature/Refund payment event

### DIFF
--- a/processor/src/routes/stripe-payment.route.ts
+++ b/processor/src/routes/stripe-payment.route.ts
@@ -51,7 +51,7 @@ export const stripeWebhooksRoutes = async (fastify: FastifyInstance, opts: Strip
   fastify.post<{ Body: string; Reply: any }>(
     '/stripe/webhooks',
     {
-      preHandler: opts.stripeHeaderAuthHook.authenticate(),
+      preHandler: [opts.stripeHeaderAuthHook.authenticate()],
       config: { rawBody: true },
     },
     async (request, reply) => {

--- a/processor/test/services/stripe-payment.service.spec.ts
+++ b/processor/test/services/stripe-payment.service.spec.ts
@@ -259,7 +259,6 @@ describe('stripe-payment.service', () => {
       jest
         .spyOn(DefaultPaymentService.prototype, 'updatePayment')
         .mockReturnValue(Promise.resolve(mockUpdatePaymentResult));
-      // Set mocked functions to Stripe and spyOn it
       Stripe.prototype.refunds = {
         create: jest.fn(),
       } as unknown as Stripe.RefundsResource;
@@ -476,37 +475,66 @@ describe('stripe-payment.service', () => {
     test('should refund a payment in ct successfully when the charge has been captured', async () => {
       const thisPaymentService: StripePaymentService = new StripePaymentService(opts);
 
-      jest.spyOn(DefaultPaymentService.prototype, 'updatePayment').mockReturnValue(Promise.resolve(mockGetPaymentResult));
+      // Set mocked functions to Stripe and spyOn it
+      Stripe.prototype.paymentIntents = {
+        retrieve: jest.fn(),
+      } as unknown as Stripe.PaymentIntentsResource;
+      jest
+        .spyOn(Stripe.prototype.paymentIntents, 'retrieve')
+        .mockReturnValue(Promise.resolve(mockStripeRetrievePaymentResult));
+      jest
+        .spyOn(DefaultPaymentService.prototype, 'updatePayment')
+        .mockReturnValue(Promise.resolve(mockGetPaymentResult));
 
       await thisPaymentService.refundPaymentInCt(mockEvent__charge_refund_captured);
 
+      expect(Stripe.prototype.paymentIntents.retrieve).toBeCalled();
       expect(DefaultPaymentService.prototype.updatePayment).toBeCalled();
     });
 
     test('should not refund a payment in ct when the charge has not been captured', async () => {
       const thisPaymentService: StripePaymentService = new StripePaymentService(opts);
 
-      jest.spyOn(DefaultPaymentService.prototype, 'updatePayment').mockReturnValue(Promise.resolve(mockGetPaymentResult));
+      jest
+        .spyOn(DefaultPaymentService.prototype, 'updatePayment')
+        .mockReturnValue(Promise.resolve(mockGetPaymentResult));
 
       await thisPaymentService.refundPaymentInCt(mockEvent__charge_refund_notCaptured);
 
+      expect(Stripe.prototype.paymentIntents.retrieve).toHaveBeenCalledTimes(0);
       expect(DefaultPaymentService.prototype.updatePayment).toHaveBeenCalledTimes(0);
     });
 
     test('should write a log when stripe.paymentIntents.retrieve function throws an error', async () => {
       const thisPaymentService: StripePaymentService = new StripePaymentService(opts);
-      jest.spyOn(DefaultPaymentService.prototype, 'getPayment').mockImplementation(() => {
-        throw new Error('error');
-      });
+
+      // Set mocked functions to Stripe and spyOn it
+      Stripe.prototype.paymentIntents = {
+        retrieve: jest.fn(),
+      } as unknown as Stripe.PaymentIntentsResource;
+      jest
+        .spyOn(Stripe.prototype.paymentIntents, 'retrieve')
+        .mockImplementation(() => {
+          throw new Error('error');
+        });
 
       await thisPaymentService.refundPaymentInCt(mockEvent__charge_refund_captured);
 
       expect(Logger.log.error).toBeCalled();
+      expect(Stripe.prototype.paymentIntents.retrieve).toHaveBeenCalledTimes(1);
+      expect(Stripe.prototype.paymentIntents.retrieve).toThrowError();
     });
 
     test('should write a log when ctPaymentService.updatePayment function throws an error', async () => {
       const thisPaymentService: StripePaymentService = new StripePaymentService(opts);
 
+      // Set mocked functions to Stripe and spyOn it
+      Stripe.prototype.paymentIntents = {
+        retrieve: jest.fn(),
+      } as unknown as Stripe.PaymentIntentsResource;
+      jest
+        .spyOn(Stripe.prototype.paymentIntents, 'retrieve')
+        .mockReturnValue(Promise.resolve(mockStripeRetrievePaymentResult));
       jest.spyOn(DefaultPaymentService.prototype, 'updatePayment').mockImplementation(() => {
         throw new Error('error');
       });
@@ -514,6 +542,8 @@ describe('stripe-payment.service', () => {
       await thisPaymentService.refundPaymentInCt(mockEvent__charge_refund_captured);
 
       expect(Logger.log.error).toBeCalled();
+      expect(DefaultPaymentService.prototype.updatePayment).toHaveBeenCalledTimes(1);
+      expect(DefaultPaymentService.prototype.updatePayment).toThrowError();
     });
   });
 


### PR DESCRIPTION
- Adjusment to get payment_intent information in order to get 'ct_payment_id' metadata and update the payment in commercetools.
- Update unit tests to cover the new code.