### PR TITLE
Added reversePayment to payment-intent API

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,14 +4,14 @@ services:
   jwt-server:
     image: node:alpine
     restart: always
-    command: 
+    command:
       - npx
       - --package
       - jwt-mock-server
       - -y
       - start
     ports:
-      - 9000:9000
+      - 9002:9000
 
   enabler:
     image: node:20
@@ -28,7 +28,7 @@ services:
       - VITE_PROCESSOR_URL=http://localhost:8080
     ports:
       - 3000:3000
-  
+
   processor:
     image: node:20
     volumes:

--- a/enabler/index.html
+++ b/enabler/index.html
@@ -65,7 +65,7 @@
         document.addEventListener("DOMContentLoaded", async () => {
           const paymentMethodSelect =
                   document.getElementById("paymentMethod");
-          const response = await fetch("http://localhost:9000/jwt/token", {
+          const response = await fetch("http://localhost:9002/jwt/token", {
             method: "POST",
             headers: {
               "Content-Type": "application/json",

--- a/enabler/src/style/_variables.scss
+++ b/enabler/src/style/_variables.scss
@@ -1,3 +1,5 @@
+@use './colors' as *;
+
 $color-black: $color-style-black;
 $color-white: $color-style-white;
 

--- a/enabler/src/style/_vx.scss
+++ b/enabler/src/style/_vx.scss
@@ -32,5 +32,3 @@
   --ctc-font-family: 'Roboto', sans-serif;
 }
 
-@import './colors';
-@import './variables';

--- a/enabler/src/style/button.module.scss
+++ b/enabler/src/style/button.module.scss
@@ -1,3 +1,6 @@
+@use "colors";
+@use "variables";
+
 @use './vx' as *;
 
 // legacy browser fallback
@@ -12,21 +15,21 @@
   padding: 0.5rem 1.375rem;
   background-color: var(--ctc-button);
   border: 0 none;
-  border-radius: $border-radius;
+  border-radius: variables.$border-radius;
   font-size: 0.9375rem;
-  font-weight: $font-weight-regular;
-  font-family: $font-family;
+  font-weight: variables.$font-weight-regular;
+  font-family: variables.$font-family;
   text-transform: uppercase;
   line-height: 1.5rem;
   letter-spacing: 0.43px;
-  box-shadow: $box-shadow;
+  box-shadow: variables.$box-shadow;
   background-position: center;
   transition: background-color 0.8s;
   cursor: pointer;
 
   &:hover {
     background: var(--ctc-button-hover)
-      radial-gradient(circle, transparent 1%, var(--ctc-button-hover) 1%) center/15000%;
+    radial-gradient(circle, transparent 1%, var(--ctc-button-hover) 1%) center/15000%;
   }
 
   &:active {
@@ -76,7 +79,7 @@
   }
 
   &.disabled {
-    color: $color-style-text-disabled;
+    color: colors.$color-style-text-disabled;
     text-decoration: none;
     cursor: not-allowed;
     pointer-events: none;
@@ -111,8 +114,8 @@
 
   &:hover {
     background: $color-style-primary-hover-background
-      radial-gradient(circle, transparent 1%, $color-style-primary-hover-background 1%)
-      center/15000%;
+    radial-gradient(circle, transparent 1%, $color-style-primary-hover-background 1%)
+    center/15000%;
   }
 
   &:active {
@@ -127,12 +130,12 @@
 
   &:disabled {
     background-color: transparent;
-    color: $color-button-disabled;
+    color: variables.$color-button-disabled;
   }
 }
 
 .errorButton {
-  color: $color-status-error-dark;
+  color: variables.$color-status-error-dark;
   background: transparent;
   border: 1px solid transparent;
   transition: none;
@@ -140,16 +143,16 @@
   outline: none;
 
   &:hover {
-    background: $color-status-error-hover;
+    background: variables.$color-status-error-hover;
   }
 
   &:active {
-    border: 1px solid $color-status-error-dark;
-    background: $color-status-error-active;
+    border: 1px solid variables.$color-status-error-dark;
+    background: variables.$color-status-error-active;
   }
 
   &:disabled {
     background-color: transparent;
-    color: $color-button-disabled;
+    color: variables.$color-button-disabled;
   }
 }

--- a/enabler/src/style/inputField.module.scss
+++ b/enabler/src/style/inputField.module.scss
@@ -1,10 +1,13 @@
+@use "colors";
+@use "variables";
+
 
 @use './vx' as *;
 
 .inputContainer {
   position: relative;
   width: 100%;
-  font-family: $font-family;
+  font-family: variables.$font-family;
   margin-bottom: 1.5rem;
 
   .inputLabel {
@@ -16,10 +19,10 @@
     font-size: 1rem;
     line-height: 1.5rem;
     background-color: transparent;
-    color: $color-border-focus;
+    color: variables.$color-border-focus;
     transition: 0.3s all;
     pointer-events: none;
-    z-index: $z-index-1;
+    z-index: variables.$z-index-1;
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
@@ -32,7 +35,7 @@
     box-sizing: border-box;
     font-size: 1rem;
     line-height: 1rem;
-    border: 1px solid $color-border-default;
+    border: 1px solid variables.$color-border-default;
     border-radius: 4px;
     &::placeholder {
       opacity: 0;
@@ -41,12 +44,12 @@
   }
 
   .inputField:hover {
-    border: 1px solid $color-border-focus;
+    border: 1px solid variables.$color-border-focus;
     cursor: pointer;
   }
 
   .helperText {
-    color: $color-text-helper;
+    color: variables.$color-text-helper;
     font-size: 0.75rem;
     line-height: 0.75rem;
     padding: 0.25rem 0.75rem 0.25rem 1rem;
@@ -61,7 +64,7 @@
     box-sizing: border-box;
     font-size: 1rem;
     line-height: 1rem;
-    border: 1px solid $color-border-default;
+    border: 1px solid variables.$color-border-default;
     border-radius: 4px;
     &::placeholder {
       opacity: 0;
@@ -110,14 +113,14 @@
 
 .hasGreyBackground.inputContainer:focus-within {
   .inputLabel {
-    background-color: $color-style-side-background;
+    background-color: colors.$color-style-side-background;
   }
 }
 
 .containValue:not(:focus-within),
 .disabledWithValue {
   .inputLabel {
-    color: $color-border-default;
+    color: variables.$color-border-default;
   }
 }
 
@@ -155,18 +158,18 @@
 .inputContainer.error {
   margin-bottom: 1rem;
   .inputField {
-    border: 2px solid $color-status-error;
+    border: 2px solid variables.$color-status-error;
     outline: none;
   }
   .helperText {
-    color: $color-status-error;
+    color: variables.$color-status-error;
   }
 }
 
 .inputContainer.error:focus-within,
 .inputContainer.error.containValue {
   .inputLabel {
-    color: $color-status-error;
+    color: variables.$color-status-error;
     max-width: calc(100% - 1rem);
   }
 }
@@ -174,12 +177,12 @@
 .inputContainer.disabled {
   .inputField {
     cursor: not-allowed;
-    border: 1px solid $color-border-default;
-    color: $color-border-default;
-    background-color: $color-text-white;
+    border: 1px solid variables.$color-border-default;
+    color: variables.$color-border-default;
+    background-color: variables.$color-text-white;
   }
   .inputLabel {
-    color: $color-border-default;
+    color: variables.$color-border-default;
   }
 }
 
@@ -190,7 +193,7 @@
 }
 
 .errorField {
-  color: $color-status-error;
+  color: variables.$color-status-error;
   font-size: 0.75rem;
   padding: 0.25rem 0.75rem 0.25rem 1rem;
 }

--- a/enabler/src/style/style.module.scss
+++ b/enabler/src/style/style.module.scss
@@ -1,5 +1,5 @@
 @use './vx' as *;
-@import './a11y';
+@use "variables";
 
 // from mock
 
@@ -21,7 +21,7 @@
 }
 
 .subHeading {
-  color: $color-text-helper;
+  color: variables.$color-text-helper;
   font-size: 0.8125rem;
   margin-top: 0.125rem;
   margin-bottom: 1.5rem;
@@ -55,8 +55,8 @@
 
   iframe {
     height: 3.317rem !important;
-    border: 1px solid $color-border-default !important;
-    border-radius: $border-radius;
+    border: 1px solid variables.$color-border-default !important;
+    border-radius: variables.$border-radius;
     padding-left: 1rem;
     width: 100%;
     float: none !important;
@@ -70,7 +70,7 @@
   }
 
   .error {
-    color: $color-status-error;
+    color: variables.$color-status-error;
     font-size: 0.75rem;
     padding: 0 0.75rem 0.25rem 1rem;
     position: rela2tive;
@@ -80,13 +80,13 @@
 /* input fields border colors */
 :global(.is-valid) {
   & iframe {
-    border: 1px solid $color-border-default !important;
+    border: 1px solid variables.$color-border-default !important;
   }
 }
 
 :global(.is-onfocus) {
   & iframe {
-    border: 2px solid $color-status-default !important;
+    border: 2px solid variables.$color-status-default !important;
   }
   ~ .error {
     display: none;
@@ -97,7 +97,7 @@
 .inputError :not(:global(.is-onfocus)),
 .inputErrorEmptyText {
   & iframe {
-    border: 2px solid $color-status-error !important;
+    border: 2px solid variables.$color-status-error !important;
   }
 }
 
@@ -141,15 +141,15 @@
 
 /* floating labels colors */
 :global(.is-valid) ~ .floatingLabel {
-  color: $color-border-default;
+  color: variables.$color-border-default;
 }
 
 :global(.is-onfocus) ~ .floatingLabel {
-  color: $color-status-default;
+  color: variables.$color-status-default;
 }
 
 :global(.is-invalid):not(.inputEmpty) ~ .floatingLabel {
-  color: $color-status-error;
+  color: variables.$color-status-error;
 }
 
 .inputErrorEmptyText ~ .floatingLabel {
@@ -168,7 +168,7 @@
 }
 
 .subHeading {
-  color: $color-text-helper;
+  color: variables.$color-text-helper;
   font-size: 0.8125rem;
   margin-top: 0.125rem;
   margin-bottom: 1.5rem;

--- a/processor/src/dtos/operations/payment-intents.dto.ts
+++ b/processor/src/dtos/operations/payment-intents.dto.ts
@@ -11,6 +11,7 @@ export const ActionCapturePaymentSchema = Type.Composite([
   }),
   Type.Object({
     amount: AmountSchema,
+    merchantReference: Type.Optional(Type.String()),
   }),
 ]);
 
@@ -20,12 +21,21 @@ export const ActionRefundPaymentSchema = Type.Composite([
   }),
   Type.Object({
     amount: AmountSchema,
+    merchantReference: Type.Optional(Type.String()),
   }),
 ]);
 
 export const ActionCancelPaymentSchema = Type.Composite([
   Type.Object({
     action: Type.Literal('cancelPayment'),
+    merchantReference: Type.Optional(Type.String()),
+  }),
+]);
+
+export const ActionReversePaymentSchema = Type.Composite([
+  Type.Object({
+    action: Type.Literal('reversePayment'),
+    merchantReference: Type.Optional(Type.String()),
   }),
 ]);
 
@@ -45,9 +55,17 @@ export const ActionCancelPaymentSchema = Type.Composite([
  * }
  */
 export const PaymentIntentRequestSchema = Type.Object({
-  actions: Type.Array(Type.Union([ActionCapturePaymentSchema, ActionRefundPaymentSchema, ActionCancelPaymentSchema]), {
-    maxItems: 1,
-  }),
+  actions: Type.Array(
+    Type.Union([
+      ActionCapturePaymentSchema,
+      ActionRefundPaymentSchema,
+      ActionCancelPaymentSchema,
+      ActionReversePaymentSchema,
+    ]),
+    {
+      maxItems: 1,
+    },
+  ),
   merchantReference: Type.Optional(Type.String()),
 });
 
@@ -74,6 +92,7 @@ export enum PaymentTransactions {
   CHARGE = 'Charge',
   CHARGE_BACK = 'Chargeback',
   REFUND = 'Refund',
+  REVERSE = 'Reverse',
 }
 
 export type PaymentIntentRequestSchemaDTO = Static<typeof PaymentIntentRequestSchema>;

--- a/processor/src/services/stripe-payment.service.ts
+++ b/processor/src/services/stripe-payment.service.ts
@@ -1,12 +1,19 @@
 import crypto from 'crypto';
 import Stripe from 'stripe';
-import { Cart, healthCheckCommercetoolsPermissions, Money, statusHandler } from '@commercetools/connect-payments-sdk';
+import {
+  Cart,
+  ErrorInvalidOperation,
+  healthCheckCommercetoolsPermissions,
+  Money,
+  statusHandler,
+} from '@commercetools/connect-payments-sdk';
 import {
   CancelPaymentRequest,
   CapturePaymentRequest,
   ConfigResponse,
   PaymentProviderModificationResponse,
   RefundPaymentRequest,
+  ReversePaymentRequest,
   StatusResponse,
 } from './types/operation.type';
 import { SupportedPaymentComponentsSchemaDTO } from '../dtos/operations/payment-componets.dto';
@@ -175,6 +182,23 @@ export class StripePaymentService extends AbstractPaymentService {
       });
 
       if (response.status === 'succeeded') {
+        await this.ctPaymentService.updatePayment({
+          id: request.payment.id,
+          transaction: {
+            type: PaymentTransactions.CHARGE,
+            amount: request.amount,
+            interactionId: response.id,
+            state: PaymentStatus.SUCCESS,
+          },
+        });
+
+        log.info(`Payment modification completed.`, {
+          paymentId: paymentIntentId,
+          action: PaymentTransactions.CHARGE,
+          result: PaymentModificationStatus.APPROVED,
+          trackingId: response.id,
+        });
+
         return {
           outcome: PaymentModificationStatus.APPROVED,
           pspReference: response.id,
@@ -204,7 +228,24 @@ export class StripePaymentService extends AbstractPaymentService {
   public async cancelPayment(request: CancelPaymentRequest): Promise<PaymentProviderModificationResponse> {
     try {
       const paymentIntentId = request.payment.interfaceId as string;
-      await stripeApi().paymentIntents.cancel(paymentIntentId);
+      const response = await stripeApi().paymentIntents.cancel(paymentIntentId);
+
+      await this.ctPaymentService.updatePayment({
+        id: request.payment.id,
+        transaction: {
+          type: PaymentTransactions.CANCEL_AUTHORIZATION,
+          amount: request.payment.amountPlanned,
+          interactionId: paymentIntentId,
+          state: PaymentStatus.SUCCESS,
+        },
+      });
+      log.info(`Payment modification completed.`, {
+        paymentId: paymentIntentId,
+        action: PaymentTransactions.CANCEL_AUTHORIZATION,
+        result: PaymentModificationStatus.APPROVED,
+        trackingId: response.id,
+      });
+
       return { outcome: PaymentModificationStatus.APPROVED, pspReference: paymentIntentId };
     } catch (error) {
       log.error('Error canceling payment in Stripe', { error });
@@ -225,10 +266,27 @@ export class StripePaymentService extends AbstractPaymentService {
     try {
       const paymentIntentId = request.payment.interfaceId as string;
       const amount = request.amount.centAmount;
-      await stripeApi().refunds.create({
+      const response = await stripeApi().refunds.create({
         payment_intent: paymentIntentId,
         amount: amount,
       });
+
+      await this.ctPaymentService.updatePayment({
+        id: request.payment.id,
+        transaction: {
+          type: PaymentTransactions.REFUND,
+          amount: request.amount,
+          interactionId: paymentIntentId,
+          state: PaymentStatus.SUCCESS,
+        },
+      });
+      log.info(`Payment modification completed.`, {
+        paymentId: request.payment.id,
+        action: PaymentTransactions.CANCEL_AUTHORIZATION,
+        result: PaymentModificationStatus.APPROVED,
+        trackingId: response.id,
+      });
+
       return { outcome: PaymentModificationStatus.RECEIVED, pspReference: paymentIntentId };
     } catch (error) {
       log.error('Error refunding payment in Stripe', { error });
@@ -237,6 +295,54 @@ export class StripePaymentService extends AbstractPaymentService {
         pspReference: request.payment.interfaceId as string,
       };
     }
+  }
+
+  /**
+   * Reverse payment
+   *
+   * @remarks
+   * Abstract method to execute payment reversals in support of automated reversals to be triggered by checkout api. The actual invocation to PSPs should be implemented in subclasses
+   *
+   * @param request
+   * @returns Promise with outcome containing operation status and PSP reference
+   */
+  public async reversePayment(request: ReversePaymentRequest): Promise<PaymentProviderModificationResponse> {
+    const hasCharge = this.ctPaymentService.hasTransactionInState({
+      payment: request.payment,
+      transactionType: 'Charge',
+      states: ['Success'],
+    });
+    const hasRefund = this.ctPaymentService.hasTransactionInState({
+      payment: request.payment,
+      transactionType: 'Refund',
+      states: ['Success', 'Pending'],
+    });
+    const hasCancelAuthorization = this.ctPaymentService.hasTransactionInState({
+      payment: request.payment,
+      transactionType: 'CancelAuthorization',
+      states: ['Success', 'Pending'],
+    });
+
+    const wasPaymentReverted = hasRefund || hasCancelAuthorization;
+
+    if (hasCharge && !wasPaymentReverted) {
+      return this.refundPayment({
+        payment: request.payment,
+        merchantReference: request.merchantReference,
+        amount: request.payment.amountPlanned,
+      });
+    }
+
+    const hasAuthorization = this.ctPaymentService.hasTransactionInState({
+      payment: request.payment,
+      transactionType: 'Authorization',
+      states: ['Success'],
+    });
+    if (hasAuthorization && !wasPaymentReverted) {
+      return this.cancelPayment({ payment: request.payment });
+    }
+
+    throw new ErrorInvalidOperation('There is no successful payment transaction to reverse.');
   }
 
   /**

--- a/processor/src/services/types/operation.type.ts
+++ b/processor/src/services/types/operation.type.ts
@@ -10,15 +10,23 @@ import { Payment } from '@commercetools/connect-payments-sdk/dist/commercetools'
 export type CapturePaymentRequest = {
   amount: AmountSchemaDTO;
   payment: Payment;
+  merchantReference?: string;
 };
 
 export type CancelPaymentRequest = {
   payment: Payment;
+  merchantReference?: string;
 };
 
 export type RefundPaymentRequest = {
   amount: AmountSchemaDTO;
   payment: Payment;
+  merchantReference?: string;
+};
+
+export type ReversePaymentRequest = {
+  payment: Payment;
+  merchantReference?: string;
 };
 
 export type PaymentProviderModificationResponse = {


### PR DESCRIPTION
This commit adds the new modified payment method of the [Checkout Payment intent API](https://docs.commercetools.com/checkout/payment-intents-api) from commercetools called '[reversePayment](https://docs.commercetools.com/checkout/payment-intents-api#paymentintentoperation)'.