### PR TITLE
fix: Update line item amount calculation in StripeShippingService

### DIFF
--- a/processor/src/services/stripe-shipping.service.ts
+++ b/processor/src/services/stripe-shipping.service.ts
@@ -97,7 +97,7 @@ export class StripeShippingService {
     try {
       const lineItems = ctCart.lineItems.map((item) => ({
           name: getLocalizedString(item.name),
-          amount: item.price.value.centAmount * item.quantity,
+          amount: item.totalPrice.centAmount,
       }));
       if (ctCart.shippingInfo && ctCart.shippingInfo.price) {
         lineItems.push({

--- a/processor/test/services/stripe-shipping.service.spec.ts
+++ b/processor/test/services/stripe-shipping.service.spec.ts
@@ -227,7 +227,7 @@ describe('StripeShippingService', () => {
       expect(result.lineItems).toEqual([
         {
           name: 'Test Product',
-          amount: 1000,
+          amount: 150000,
         },
         {
           name: 'Shipping',
@@ -285,7 +285,7 @@ describe('StripeShippingService', () => {
       expect(result.lineItems).toEqual([
         {
           name: 'Test Product',
-          amount: 1000,
+          amount: 150000,
         },
       ]);
     });


### PR DESCRIPTION
- Changed the line item amount calculation to use `totalPrice.centAmount` instead of `price.value.centAmount * quantity`, ensuring accurate total pricing for shipping items in the cart.