### PR TITLE
Enhance Subscription monthly order creation

### DIFF
--- a/processor/src/services/stripe-subscription.service.ts
+++ b/processor/src/services/stripe-subscription.service.ts
@@ -1739,6 +1739,10 @@ export class StripeSubscriptionService {
       customerId: customer.id,
       customerEmail: customer.email,
       country: originalOrder.shippingAddress?.country || originalOrder.billingAddress?.country || 'US',
+      taxMode: originalOrder.taxMode || 'Platform',
+      taxRoundingMode: originalOrder.taxRoundingMode || 'HalfEven',
+      taxCalculationMode: originalOrder.taxCalculationMode || 'LineItemLevel',
+      priceRoundingMode: originalOrder.priceRoundingMode || 'HalfEven',
     };
 
     let newCart = await createCartFromDraft(cartDraft);

--- a/processor/test/services/stripe-subscription.service.private-methods.spec.ts
+++ b/processor/test/services/stripe-subscription.service.private-methods.spec.ts
@@ -511,6 +511,10 @@ describe('StripeSubscriptionService - Private Methods', () => {
         customerId: mockCustomer.id,
         customerEmail: mockCustomer.email,
         country: 'US',
+        taxMode: 'Platform',
+        taxRoundingMode: 'HalfEven',
+        taxCalculationMode: 'LineItemLevel',
+        priceRoundingMode: 'HalfEven',
       });
       expect(CartClient.updateCartById).toHaveBeenCalled();
       expect(CartClient.getCartExpanded).toHaveBeenCalled();
@@ -562,6 +566,10 @@ describe('StripeSubscriptionService - Private Methods', () => {
         customerId: mockCustomer.id,
         customerEmail: mockCustomer.email,
         country: 'US',
+        taxMode: 'Platform',
+        taxRoundingMode: 'HalfEven',
+        taxCalculationMode: 'LineItemLevel',
+        priceRoundingMode: 'HalfEven',
       });
       expect(CartClient.updateCartById).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
This pull request updates the `StripeSubscriptionService` to support additional tax and price rounding configuration options when creating carts, and ensures these new fields are properly tested in the private methods unit tests.

Enhancements to cart creation logic:

* Added support for `taxMode`, `taxRoundingMode`, `taxCalculationMode`, and `priceRoundingMode` fields when drafting a cart in `stripe-subscription.service.ts`, defaulting to sensible values if not provided.

Test coverage improvements:

* Updated private methods unit tests in `stripe-subscription.service.private-methods.spec.ts` to verify that the new tax and price rounding fields are correctly included in cart drafts. [[1]](diffhunk://#diff-888fc269d83212a0dd62bd4800dbc5a83f488b35393ced8cd5b43f320e867c95R514-R517) [[2]](diffhunk://#diff-888fc269d83212a0dd62bd4800dbc5a83f488b35393ced8cd5b43f320e867c95R569-R572)