### PR TITLE
Adding grounding files (claude, security) and improving readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,11 @@
 #Context documentation
 docs/context7-libraries
 context
-CLAUDE.md
+
 context7-config.json
+
+# Internal security documents (not for public repo)
+docs/security-findings.md
 
 # Connect CLI generated files
 .connect

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,20 @@ These are non-negotiable design rules. Do not violate them.
 - **Metadata is the bridge.** Stripe payment intents carry CT identifiers (cart_id, payment_id, customer_id, etc.) in their metadata. This metadata must always be set during creation and must never be modified after.
 - **Webhook events drive state updates.** Payment/order state changes happen via webhook processing (eventual consistency), not via synchronous API responses.
 
+### Payment Flow Integrity
+
+- **This connector uses Stripe's deferred intent pattern.** Elements are mounted with `mode` + `amount` + `currency` but NO `clientSecret`. The PaymentIntent is created server-side at submit time (`POST /payments`), not at page load or component mount. This means no PI exists until the customer commits to paying.
+- **Cart freeze is the integrity guarantee.** When a PI is created, the cart is frozen immediately after. A frozen cart cannot be modified (no item additions, quantity changes, or shipping updates). This guarantees that `PI amount === cart total` for the lifetime of the PI. Do not add code paths that break this invariant.
+- **Amount validation is intentionally not hardcoded in the webhook handler.** In automatic capture, PI amount always equals the cart total (guaranteed by cart freeze). In manual capture, multi-capture, incremental auth, and extended auth, the captured amount legitimately differs from the original authorization. A hard amount check would break these flows. The existing warn on unfrozen cart at `payment_intent.succeeded` is the correct signal for anomalies.
+- **Do not add amount validation that blocks order creation** unless it is scoped to `capture_method === 'automatic'` only.
+
+### Route Flow Separation
+
+- **Shipping routes (`/shipping-methods/*`) are Express Checkout infrastructure only.** They exist to support the Apple Pay / Google Pay sheet's shipping address and rate selection lifecycle. The enabler wires them exclusively to `StripeExpressCheckoutElement` events (`shippingaddresschange`, `shippingratechange`, `cancel`). Payment Element flows never call these routes.
+- **`GET /shipping-methods/remove` is the Express Checkout cancellation handler.** It unfreezes the cart because the Express Checkout flow was abandoned. In the deferred intent pattern, no PI has been created at the time of cancellation (PI creation only happens on `confirm`, which is mutually exclusive with `cancel`). The unfreeze is correct behavior -- it releases the cart for further shopping.
+- **`getShippingMethods` and `updateShippingRate` temporarily unfreeze and re-freeze.** This handles the case where the cart may be frozen from a prior flow. These methods always restore the original frozen state after the shipping update.
+- **Do not add general-purpose unfreeze endpoints.** Cart freeze/unfreeze is tied to specific payment lifecycle events, not exposed as a standalone operation.
+
 ### Configuration
 
 - **Secrets go in `securedConfiguration` in `connect.yaml`.** Never in `standardConfiguration`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,199 @@
+# CLAUDE.md
+
+Guidelines for AI-assisted development on the Stripe Payment Connector for Composable Commerce.
+
+## Project Overview
+
+This is a **Commercetools Connect** payment connector that integrates Stripe with Commercetools. It consists of two packages:
+
+- **processor** (`/processor`): Node.js backend service (Fastify v5, TypeScript) that handles payment operations, webhook events, and Stripe/CT translation
+- **enabler** (`/enabler`): Frontend component library (Vite) wrapping Stripe Payment Element for merchant storefronts
+
+The connector runs inside the Commercetools Connect managed runtime. Users install it via marketplace or import as a custom application. Users configure it through environment variables only -- they do not manage infrastructure.
+
+## Architecture Invariants
+
+These are non-negotiable design rules. Do not violate them.
+
+### Authentication
+
+- **Every route must have a `preHandler` auth hook.** No exceptions. Choose the correct one:
+  - `sessionHeaderAuthHook.authenticate()` -- for frontend-facing endpoints (called by merchant storefront via enabler)
+  - `oauth2AuthHook.authenticate()` + `authorizationHook.authorize(...)` -- for backend/service-to-service endpoints
+  - `jwtAuthHook.authenticate()` -- for internal service endpoints (status, payment-components)
+  - `stripeHeaderAuthHook.authenticate()` -- for webhook endpoint only (paired with `constructEvent()`)
+- **`constructEvent()` is the sole cryptographic guard for webhooks.** The `StripeHeaderAuthHook` is a lightweight pre-filter only. This is Stripe's prescribed pattern. Do not attempt to "fix" the hook by adding signature verification there unless you also remove `constructEvent()` from the route (consolidation is acceptable, but both must not verify independently).
+- **Raw body must be preserved for webhook routes.** The `fastify-raw-body` plugin is configured for `/stripe/webhooks` specifically. If adding new webhook routes, ensure they are included in the `routes` array.
+
+### Data Flow
+
+- **Stripe is the source of truth for payment state.** The connector translates Stripe events into Commercetools payment transactions -- never the reverse.
+- **Commercetools is the source of truth for prices.** Subscription price sync reads prices from CT and updates Stripe, not the other way around.
+- **Metadata is the bridge.** Stripe payment intents carry CT identifiers (cart_id, payment_id, customer_id, etc.) in their metadata. This metadata must always be set during creation and must never be modified after.
+- **Webhook events drive state updates.** Payment/order state changes happen via webhook processing (eventual consistency), not via synchronous API responses.
+
+### Configuration
+
+- **Secrets go in `securedConfiguration` in `connect.yaml`.** Never in `standardConfiguration`.
+- **All secrets must be listed as `required: true`** in connect.yaml. The runtime enforces this at deployment.
+- **Config defaults in `config.ts` are for local development only.** The runtime enforces required fields. But do not use real-looking defaults (e.g., `'sk_test_...'`). Use empty strings or obviously fake values.
+
+## Security Rules
+
+### Never do these:
+
+- **Never return raw error objects to clients.** No `JSON.stringify(error)`, no `error.message`, no `String(error)` in HTTP responses. Log the full error server-side, return a generic message to the client.
+  ```typescript
+  // BAD
+  return reply.status(400).send({ error: JSON.stringify(error) });
+  return reply.status(400).send(`Webhook Error: ${err.message}`);
+
+  // GOOD
+  log.error('Payment confirmation failed', { error: err.message, paymentId: id });
+  return reply.status(400).send({ outcome: 'rejected', error: 'Payment processing failed.' });
+  ```
+
+- **Never use `console.log`, `console.error`, or `console.warn` in the processor.** Use the structured logger from `@commercetools-backend/loggers`. Console statements bypass log-level filtering, lack correlation IDs, and may expose sensitive data in log aggregation systems.
+  ```typescript
+  // BAD
+  console.log('error', JSON.stringify(error, null, 2));
+
+  // GOOD
+  log.error('Operation failed', { error: error instanceof Error ? error.message : 'Unknown' });
+  ```
+
+- **Never trust or forward user input without validation.** All URL params, query params, and body fields must have Typebox schema validation with format constraints (minLength, maxLength, pattern) -- not just `Type.String()`.
+
+- **Never hardcode secrets, API keys, or tokens.** Even in tests, use environment variables or mock values.
+
+- **Never merge with `origin: '*'` removed from CORS without providing a `CORS_ALLOWED_ORIGINS` env var alternative.** The `origin: '*'` is intentional for composable commerce -- merchants embed the enabler on their own domains. If you need to restrict CORS, make it configurable.
+
+### Always do these:
+
+- **Validate webhook events with `constructEvent()` before processing.** Always use `request.rawBody` (not `request.body`) for signature verification.
+- **Set metadata on Stripe objects during creation.** Cart ID, payment ID, customer ID, and project key must always be present in payment intent metadata.
+- **Use the connect-payments-sdk auth hooks.** Do not build custom auth middleware. The SDK hooks handle JWT validation, OAuth2 token introspection, and session management.
+- **Return appropriate HTTP status codes:** 200 for success, 400 for client errors, 401 for auth failures, 500 for unexpected errors. Never return 200 with an error body.
+
+## Input Validation Requirements
+
+When adding or modifying routes, follow this pattern:
+
+```typescript
+// Route schema with proper validation
+{
+  schema: {
+    params: Type.Object({
+      customerId: Type.String({ minLength: 1, maxLength: 128, pattern: '^[a-zA-Z0-9_-]+$' }),
+    }),
+    body: Type.Object({
+      amount: Type.Integer({ minimum: 1 }),
+      currency: Type.String({ minLength: 3, maxLength: 3, pattern: '^[a-z]{3}$' }),
+    }),
+    required: ['customerId'] as const,
+  },
+}
+```
+
+- String IDs: `minLength: 1, maxLength: 128`
+- Enum-like strings: use `Type.Union([Type.Literal('a'), Type.Literal('b')])`
+- Numeric fields: use `Type.Integer()` with `minimum`/`maximum`
+- Optional fields: use `Type.Optional(...)` -- never rely on `undefined` checks in handler code
+
+## Code Patterns
+
+### Adding a new route
+
+1. Define the route in the appropriate route file under `processor/src/routes/`
+2. Add Typebox schema validation for all params, query, and body
+3. Add the correct `preHandler` auth hook
+4. Handle errors with try/catch, log server-side, return sanitized response
+5. Add corresponding tests in `processor/test/`
+
+### Adding a new webhook event handler
+
+1. Add the event type to `StripeEvent` enum in constants
+2. Add a case in the webhook switch in `stripe-payment.route.ts`
+3. Determine if the event comes from a subscription invoice (`isFromSubscriptionInvoice()`) and route accordingly
+4. Implement the handler in the appropriate service (`stripe-payment.service.ts` or `stripe-subscription.service.ts`)
+5. Use `StripeEventConverter` to translate the event to CT payment update format
+6. Test with Stripe CLI webhook forwarding locally
+
+### Adding a new environment variable
+
+1. Add it to `processor/src/config/config.ts` with a sensible default
+2. Add it to `connect.yaml` under `standardConfiguration` or `securedConfiguration`
+3. If it's a secret, it MUST go in `securedConfiguration` with `required: true`
+4. Document it in the processor README with description, example value, and default
+5. If it changes behavior, add it to the README features section
+
+## Testing
+
+- **Framework**: Jest v30+ with `ts-jest`
+- **Mocking**: MSW (Mock Service Worker) for HTTP mocking
+- **Location**: `processor/test/`
+- **Run**: `cd processor && npm test`
+- **Lint**: `cd processor && npm run lint`
+
+### What to test
+
+- Every route handler: happy path + error cases + auth failures
+- Webhook event processing: each event type with valid and invalid payloads
+- Service methods: business logic with mocked external dependencies
+- Config validation: missing/invalid environment variables
+
+### What NOT to test
+
+- Stripe SDK internals (trust `constructEvent()`, `paymentIntents.create()`, etc.)
+- Commercetools SDK internals
+- The Connect runtime itself
+
+## File Structure Quick Reference
+
+```
+processor/src/
+├── main.ts                          # Entry point
+├── config/config.ts                 # Environment config
+├── server/server.ts                 # Fastify setup
+├── server/plugins/                  # Plugin autoloading
+├── routes/
+│   ├── stripe-payment.route.ts      # Payment + webhook routes
+│   ├── stripe-subscription.route.ts # Subscription routes
+│   ├── stripe-customer.route.ts     # Customer routes
+│   ├── stripe-shipping.route.ts     # Shipping routes
+│   └── operation.route.ts           # Capture/refund/cancel + status
+├── services/
+│   ├── stripe-payment.service.ts    # Payment business logic
+│   ├── stripe-subscription.service.ts # Subscription business logic
+│   ├── stripe-customer.service.ts   # Customer management
+│   ├── stripe-shipping.service.ts   # Shipping integration
+│   └── converters/                  # Stripe event → CT payment converters
+├── clients/
+│   └── stripe.client.ts             # Stripe SDK initialization
+├── libs/fastify/
+│   ├── hooks/                       # Auth hooks
+│   ├── context/                     # Request context management
+│   └── error-handler.ts             # Global error handler
+├── dtos/                            # Typebox schema definitions
+├── custom-types/                    # CT custom type definitions
+├── connectors/                      # Pre/post deploy scripts
+└── constants.ts                     # Metadata field names, enums
+```
+
+## Key Dependencies
+
+| Package | Purpose | Version Policy |
+|---|---|---|
+| `stripe` | Stripe API client | Caret (`^`) -- allow minor updates |
+| `fastify` | HTTP server framework | Caret (`^`) |
+| `@commercetools/connect-payments-sdk` | Auth hooks, session management, request context | Caret (`^`) |
+| `@sinclair/typebox` | Request/response schema validation | Caret (`^`) |
+| `@commercetools-backend/loggers` | Structured logging | Caret (`^`) |
+
+## Related Documentation
+
+- [SECURITY.md](./SECURITY.md) -- Security policy, shared responsibility, threat model
+- [Processor README](./processor/README.md) -- Detailed processor docs, subscription config, API reference
+- [Enabler README](./enabler/README.md) -- Frontend component integration guide
+- [Stripe Webhook Docs](https://docs.stripe.com/webhooks) -- Stripe's webhook verification reference
+- [Commercetools Connect Docs](https://docs.commercetools.com/connect) -- Runtime platform documentation

--- a/README.md
+++ b/README.md
@@ -135,106 +135,6 @@ Once the payment component is set up, the connector orchestrates various payment
 
 Each diagram details the interactions and steps involved in processing the respective payment type.
 
-## Recent Updates and Improvements
-
-### Multiple Refunds and Multicapture Implementation (Latest) - OPT-IN FEATURE
-
-The payment processing system has been significantly enhanced with advanced multicapture and refund capabilities. **These features are opt-in and disabled by default** to ensure backward compatibility.
-
-#### ⚙️ Configuration Required
-- **Environment Variable**: `STRIPE_ENABLE_MULTI_OPERATIONS=true` (default: `false`)
-- **Prerequisites**:
-  - Multicapture must be enabled in your Stripe account
-  - Set `STRIPE_CAPTURE_METHOD=manual`
-  - Webhook endpoint must include `charge.updated` and `charge.refunded` events
-- **Default Behavior**: When disabled, webhook events are gracefully skipped with logging
-- **Backward Compatible**: Existing merchants experience no disruption
-
-#### 🚀 New Features (When Enabled)
-- **Multicapture Support**: Enhanced payment capture functionality to support multiple partial captures on the same payment intent
-- **Advanced Refund Processing**: New refund handling that fetches accurate refund details directly from Stripe API
-- **Incremental Capture Tracking**: Sophisticated tracking of incremental captured amounts using Stripe's previous attributes
-- **Conditional Webhook Routing**: Dedicated event handlers for `charge.updated` and `charge.refunded` events that only process when feature is enabled
-- **Balance Transaction Tracking**: Improved PSP reference tracking using Stripe balance transaction IDs
-
-#### 🔧 Technical Improvements
-- **API-Based Refund Details**: Refund processing now fetches actual refund amounts and IDs from Stripe API for precise transaction records
-- **Partial Capture Detection**: Automatic detection of partial captures with proper `final_capture` handling
-- **Simplified Payment Updates**: Removed manual commercetools payment updates in favor of webhook-based processing
-- **Enhanced Error Handling**: Comprehensive validation and error management for multicapture scenarios
-- **Improved Event Converter**: Added support for `CHARGE__UPDATED` events and enhanced refund processing
-
-#### 🧪 Testing Infrastructure Enhancements
-- **Comprehensive Test Coverage**: Updated test suites to cover all new multicapture and refund functionality
-- **Enhanced Webhook Testing**: Improved webhook routing tests for new event types
-- **Converter Testing**: Added tests for new event converter functionality
-- **Edge Case Coverage**: Enhanced testing for various multicapture and refund scenarios
-
-#### 📚 Documentation and Architecture Updates
-- **Enhanced Webhook Documentation**: Updated webhook event descriptions to reflect new capabilities
-- **Improved Transaction Tracking**: Better PSP reference tracking for audit and debugging purposes
-- **Comprehensive Logging**: Enhanced logging throughout the payment processing pipeline
-- **Better Error Management**: Structured error handling with detailed transaction information
-
-### Enhanced Subscription Service Architecture and Testing Infrastructure
-
-The subscription service has undergone major architectural improvements with comprehensive testing enhancements:
-
-#### 🚀 New Features
-- **New Price Client Service**: Added dedicated `price-client.ts` service for enhanced product price management and retrieval
-- **Modular Test Architecture**: Restructured subscription service tests into focused, maintainable modules:
-  - Business logic and payment handling tests
-  - Core subscription functionality tests  
-  - Subscription lifecycle management tests
-  - Payment processing and confirmation tests
-  - Price management and calculation tests
-  - Utility functions and helper method tests
-- **Enhanced Configuration Management**: Added comprehensive configuration testing and validation
-- **Advanced Payment Intent Handling**: Enhanced error handling for payment intents with additional status checks
-- **Improved Subscription Metadata Management**: Enhanced metadata tracking with comprehensive field mapping
-
-#### 🔧 Technical Improvements
-- **Subscription Service Refactoring**: Major architectural improvements with better separation of concerns
-- **Enhanced Test Coverage**: Achieved comprehensive test coverage across all subscription service methods and edge cases
-- **Improved Mock Data Management**: Enhanced mock data structures for better test reliability and coverage
-- **Better Error Handling**: Comprehensive error management throughout the subscription service with detailed logging
-- **Payment Processing Enhancements**: Improved payment intent configuration with conditional shipping and advanced payment method options
-- **New Price Management Methods**: 
-  - `getProductById()`: Retrieves products with expanded price information
-  - `getProductMasterPrice()`: Gets current price from product master variant
-
-#### 🧪 Testing Infrastructure Enhancements
-- **Modular Test Structure**: Tests organized by functionality for better maintainability and faster execution
-- **Comprehensive Coverage**: All subscription service methods now have dedicated test coverage
-- **Enhanced Mock Data**: Improved mock data for realistic testing scenarios
-- **Better Test Organization**: Clear separation between unit tests and integration tests
-- **Configuration Testing**: Added dedicated tests for configuration validation
-
-#### 📚 Documentation and Architecture Updates
-- **Enhanced Code Organization**: Better separation of concerns in subscription service architecture
-- **Improved Type Safety**: Updated method signatures and type definitions for better development experience
-- **Better Logging**: Enhanced logging throughout the service for improved debugging capabilities
-- **Optimized Performance**: More efficient product price management and test execution
-
-### Previous Enhancements
-
-#### Subscription Service Core Features
-- **Recurring Shipping Fee Support**: Added comprehensive support for recurring shipping fees in subscriptions
-- **Automatic Shipping Price Management**: Automatic creation and management of Stripe shipping prices
-- **Enhanced Metadata Tracking**: Improved metadata handling for shipping methods and prices
-- **Shipping Price Integration**: New methods for managing shipping prices within subscriptions:
-  - `getSubscriptionShippingPriceId()`: Retrieves or creates shipping price IDs
-  - `getStripeShippingPriceByMetadata()`: Searches for existing shipping prices
-  - `createStripeShippingPrice()`: Creates new Stripe shipping prices
-- **Enhanced Type Definitions**: Added new TypeScript interfaces for shipping price management
-- **Enabler Enhancements**: Improved payment mode handling and comprehensive debugging
-
-For detailed information about these improvements, see the [Processor Documentation](./processor/README.md#subscription-shipping-fee-support).
-
-For technical implementation details, see the [Subscription Shipping Fee Integration Guide](./docs/subscription-shipping-fee.md).
-
-For enabler and payment service improvements, see the [Enabler Improvements Guide](./docs/enabler-improvements.md).
-
 # Webhooks
 
 The following webhooks are currently supported, and the payment transactions in commercetools are:
@@ -442,8 +342,8 @@ For complete implementation details, refer to the [Google Pay considerations in 
 
 ## Deployment Configuration
 
-It needs to be published to deploy your customized connector application on commercetools Connect. For details, please refer to [documentation about commercetools Connect](https://docs.commercetools.com/connect/concepts)
-In addition, the tax integration connector template has a folder structure, as listed below, to support Connect.
+It needs to be published to deploy your customized connector application on commercetools Connect. For details, please refer to [documentation about commercetools Connect](https://docs.commercetools.com/connect/concepts).
+The connector follows this folder structure:
 
 ```
 ├── enabler
@@ -457,157 +357,73 @@ In addition, the tax integration connector template has a folder structure, as l
 └── connect.yaml
 ```
 
-The connect deployment configuration specifie in `connect.yaml`, the information needed to publish the application. Following is the deployment configuration used by the Enabler and Processor modules
 
-```
-deployAs:
-  - name: enabler
-    applicationType: assets
-  - name: processor
-    applicationType: service
-    endpoint: /
-    scripts:
-      postDeploy: npm install && npm run connector:post-deploy
-      preUndeploy: npm install && npm run connector:pre-undeploy
-    configuration:
-      standardConfiguration:
-        - key: CTP_PROJECT_KEY
-          description: commercetools project key
-          required: true
-        - key: CTP_AUTH_URL
-          description: commercetools Auth URL (example - https://auth.europe-west1.gcp.commercetools.com).
-          required: true
-          default: https://auth.europe-west1.gcp.commercetools.com
-        - key: CTP_API_URL
-          description: commercetools API URL (example - https://api.europe-west1.gcp.commercetools.com).
-          required: true
-          default: https://api.europe-west1.gcp.commercetools.com
-        - key: CTP_SESSION_URL
-          description: Session API URL (example - https://session.europe-west1.gcp.commercetools.com).
-          required: true
-          default: https://session.europe-west1.gcp.commercetools.com
-        - key: CTP_CHECKOUT_URL
-          description: Checkout API URL (example - https://checkout.europe-west1.gcp.commercetools.com).
-          required: true
-        - key: CTP_JWKS_URL
-          description: JWKs url (example - https://mc-api.europe-west1.gcp.commercetools.com/.well-known/jwks.json)
-          required: true
-          default: https://mc-api.europe-west1.gcp.commercetools.com/.well-known/jwks.json
-        - key: CTP_JWT_ISSUER
-          description: JWT Issuer for jwt validation (example - https://mc-api.europe-west1.gcp.commercetools.com)
-          required: true
-          default: https://mc-api.europe-west1.gcp.commercetools.com
-        - key: STRIPE_CAPTURE_METHOD
-          description: Stripe capture method (example - manual|automatic).
-          default: automatic
-        - key: STRIPE_WEBHOOK_ID
-          description: Stripe unique identifier for the Webhook Endpoints (example - we_*****).
-          required: true
-        - key: STRIPE_APPEARANCE_PAYMENT_ELEMENT
-          description: Stripe Appearance for Payment Element (example - {"theme":"stripe","variables":{"colorPrimary":"\#0570DE","colorBackground":"\#FFFFFF","colorText":"\#30313D","colorDanger":"\#DF1B41","fontFamily":"Ideal Sans,system-ui,sansserif","spacingUnit":"2px","borderRadius":"4px"}}).
-        - key: STRIPE_APPEARANCE_EXPRESS_CHECKOUT
-          description: Stripe Appearance for Express Checkout (example - {"theme":"stripe","variables":{"colorPrimary":"\#0570DE","colorBackground":"\#FFFFFF","colorText":"\#30313D","colorDanger":"\#DF1B41","fontFamily":"Ideal Sans,system-ui,sansserif","spacingUnit":"2px","borderRadius":"4px"}}).
-        - key: STRIPE_LAYOUT
-          description: Stripe Layout for Payment Element (example - {"type":"accordion","defaultCollapsed":false,"radios":true,"spacedAccordionItems":false} ).
-          default: '{"type":"tabs","defaultCollapsed":false}'
-        - key: STRIPE_PUBLISHABLE_KEY
-          description: Stripe Publishable Key
-          required: true
-        - key: STRIPE_APPLE_PAY_WELL_KNOWN
-          description: Domain association file from Stripe. (example - https://stripe.com/files/apple-pay/apple-developer-merchantid-domain-association)
-        - key: STRIPE_SAVED_PAYMENT_METHODS_CONFIG
-          description: Stripe configuration for saved payment methods (example - {"payment_method_save":"enabled","payment_method_save_usage":"off_session","payment_method_redisplay":"enabled","payment_method_redisplay_limit":10}).
-          default: '{"payment_method_save":"disabled"}'
-        - key: MERCHANT_RETURN_URL
-          description: Merchant return URL
-          required: true
-        - key: STRIPE_COLLECT_BILLING_ADDRESS
-          description: Stripe collect billing address information in Payment Element (example - 'auto' | 'never' | 'if_required').
-          default: 'auto'
-          required: true
-        - key: STRIPE_SUBSCRIPTION_PAYMENT_HANDLING
-          description: Subscription payment handling strategy (createOrder|addPaymentToOrder).
-          default: createOrder
-        - key: STRIPE_SUBSCRIPTION_PRICE_SYNC_ENABLED
-          description: Enable automatic price synchronization for subscriptions (true|false).
-          default: false
-        - key: STRIPE_ENABLE_MULTI_OPERATIONS
-          description: Enable multicapture and multirefund support (true|false). When enabled, allows multiple partial captures and multiple refunds on payments. IMPORTANT - Requires multicapture to be enabled in your Stripe account.
-          default: 'false'
-        - key: STRIPE_API_VERSION
-          description: Stripe API version to use (example - 2025-12-15.clover).
-          default: '2025-12-15.clover'
-        - key: CT_CUSTOM_TYPE_LAUNCHPAD_PURCHASE_ORDER_KEY
-          description: Custom type key for launchpad purchase order number.
-          required: true
-          default: 'payment-launchpad-purchase-order'
-        - key: CT_CUSTOM_TYPE_STRIPE_CUSTOMER_KEY
-          description: Custom type key for Stripe customer ID.
-          required: true
-          default: 'payment-connector-stripe-customer-id'
-        - key: CT_CUSTOM_TYPE_SUBSCRIPTION_LINE_ITEM_KEY
-          description: Custom type key for subscription line item.
-          required: true
-          default: 'payment-connector-subscription-line-item-type'
-        - key: CT_PRODUCT_TYPE_SUBSCRIPTION_KEY
-          description: Product type key for subscription information.
-          required: true
-          default: 'payment-connector-subscription-information'
-      securedConfiguration:
-        - key: CTP_CLIENT_SECRET
-          description: commercetools client secret.
-          required: true
-        - key: CTP_CLIENT_ID
-          description: commercetools client ID with manage_payments, manage_orders, view_sessions, view_api_clients, manage_checkout_payment_intents, introspect_oauth_tokens, manage_types and view_types scopes
-          required: true
-        - key: STRIPE_SECRET_KEY
-          description: Stripe secret key (example - sk_*****).
-          required: true
-        - key: STRIPE_WEBHOOK_SIGNING_SECRET
-          description: Stripe Webhook signing secret  (example - whsec_*****).
-          required: true
+The deployment configuration is defined in [`connect.yaml`](./connect.yaml). This file declares the enabler and processor applications, their deployment scripts, and all configuration variables. Refer to `connect.yaml` as the source of truth.
 
-```
+### Configuration Reference
 
-Here, you can see the details about various variables in the configuration
-- `CTP_PROJECT_KEY`: The key to the commercetools composable commerce project.
-- `CTP_SCOPE`: The scope constrains the endpoints to which the commercetools client has access and the read/write access right to an endpoint.
-- `CTP_AUTH_URL`: The URL for authentication in the commercetools platform. Generate the OAuth 2.0 token required in every API call to commercetools composable commerce. The default value is `https://auth.europe-west1.gcp.commercetools.com`. For details, please refer to the documentation [here](https://docs.commercetools.com/tutorials/api-tutorial#authentication).
-- `CTP_API_URL`: The URL for commercetools composable commerce API. The default value is `https://api.europe-west1.gcp.commercetools.com`.
-- `CTP_SESSION_URL`: The URL for session creation in the commercetools platform. Connectors rely on the session created to share information between the enabler and processor. The default value is `https://session.europe-west1.gcp.commercetools.com`.
-- `CTP_CHECKOUT_URL`: The URL for commercetools Checkout API. Required for checkout-related operations. Example: `https://checkout.europe-west1.gcp.commercetools.com`.
-- `CTP_JWKS_URL`: The JSON Web Key Set URL. Default value is `https://mc-api.europe-west1.gcp.commercetools.com/.well-known/jwks.json`
-- `CTP_JWT_ISSUER`: The issuer inside JSON Web Token, required in the JWT validation process. The default value is `https://mc-api.europe-west1.gcp.commercetools.com`
-- `STRIPE_CAPTURE_METHOD`: Stripe capture method (manual or automatic), default value: automatic.
-- `STRIPE_APPEARANCE_PAYMENT_ELEMENT`: Stripe Elements supports visual customization, which allows you to match the design of your site with the `appearance` option. This value has the specific appearance of the Payment Element component. The value needs to be a valid stringified JSON. More information about the properties can be found [here](https://docs.stripe.com/elements/appearance-api).
-- `STRIPE_APPEARANCE_EXPRESS_CHECKOUT`: Stripe Elements supports visual customization, which allows you to match the design of your site with the `appearance` option. This value has the specific appearance of the Express Checkout component.
-- `STRIPE_LAYOUT`: Stripe allows you to customize the Payment Element's Layout to fit your checkout flow (accordions or tabs). Default value is `{"type":"tabs","defaultCollapsed":false}`
-- `STRIPE_APPLE_PAY_WELL_KNOWN`: Domain association file from Stripe. We can find more information in this [link](https://stripe.com/files/apple-pay/apple-developer-merchantid-domain-association).
-- `CTP_CLIENT_SECRET`: The client secret of commercetools composable commerce user account. It is used in commercetools for clients to communicate with commercetools composable commerce via SDK.
-- `CTP_CLIENT_ID`: The client ID of your commercetools composable commerce user account. It is used in commercetools for clients to communicate with commercetools composable commerce via SDK. Expected scopes are: `manage_payments` `manage_orders` `view_sessions` `view_api_clients` `manage_checkout_payment_intents` `introspect_oauth_tokens` `manage_types` `view_types`.
-- `STRIPE_SECRET_KEY`: Stripe authenticates your API requests using your account's API keys
-- `STRIPE_PUBLISHABLE_KEY`: Stripe authenticates your frontend requests using your account's Publishable keys
-- `STRIPE_WEBHOOK_ID`: Stripe unique identifier for the [Webhook Endpoints](https://docs.stripe.com/api/webhook_endpoints)
-- `STRIPE_WEBHOOK_SIGNING_SECRET`: Stripe Secret key to verify webhook signatures using the official libraries. This key is created in the [Stripe dashboard Webhook](https://docs.stripe.com/webhooks).
-- `MERCHANT_RETURN_URL`: Merchant return URL used on the [confirmPayment](https://docs.stripe.com/js/payment_intents/confirm_payment) return_url parameter. The Buy Now Pay Later payment methods will send the Stripe payment_intent in the URL; the Merchant will need to retrieve the payment intent and look for the metadata `ct_payment_id` to be added in the commercetools Checkout SDK `paymentReference`.
-- `STRIPE_SAVED_PAYMENT_METHODS_CONFIG`: Stripe allows you to configure the saved payment methods in the Payment Element, refer to [docs](https://docs.stripe.com/api/customer_sessions/object#customer_session_object-components-payment_element-features). This feature is disabled by default. To enable it, you need to add the expected customer session object. Default value is `{"payment_method_save":"disabled"}`
-- `STRIPE_COLLECT_BILLING_ADDRESS`: Stripe allows you to collect the shipping address in the Payment Element. If you want to collect the shipping address, you need to set this value to `never`. The default value is `auto`. More information can be found [here](https://docs.stripe.com/payments/payment-element/control-billing-details-collection).
-- `STRIPE_SUBSCRIPTION_PAYMENT_HANDLING`: Defines the strategy for handling subscription payments. Options are:
-  - `createOrder` (creates a new order for each subscription payment - default)
-  - `addPaymentToOrder` (adds payment to existing order)
-- `STRIPE_SUBSCRIPTION_PRICE_SYNC_ENABLED`: Enables automatic price synchronization for subscriptions.
-  - `true`: Subscription prices are automatically synchronized with current commercetools product prices **before** each invoice is created via `invoice.upcoming` webhook events (price changes take effect in current billing cycle)
-  - `false` (default): Price updates happen **after** invoice payment via `createOrder` method (price changes take effect in next billing cycle)
-- `STRIPE_ENABLE_MULTI_OPERATIONS`: **Opt-in Feature** - Enables multicapture and multirefund support.
-  - `true`: Enables multiple partial captures and multiple refunds on payments. Sets `request_multicapture: 'if_available'` on payment intents. Processes `charge.updated` and `charge.refunded` webhook events.
-  - `false` (default): Standard single-capture payment processing. Webhook events are gracefully skipped with informative logging.
-  - **Prerequisites**: Requires multicapture enabled in your Stripe account AND `STRIPE_CAPTURE_METHOD=manual`
-  - **See**: [Multiple Refunds and Multicapture Documentation](./docs/multiple-refunds-multicapture.md) for detailed configuration
-- `STRIPE_API_VERSION`: Stripe API version to use. Default value is `2025-12-15.clover`. Allows merchants to pin to specific Stripe API versions for stability.
-- `CT_CUSTOM_TYPE_LAUNCHPAD_PURCHASE_ORDER_KEY`: Custom type key for launchpad purchase order number. Default: `payment-launchpad-purchase-order`.
-- `CT_CUSTOM_TYPE_STRIPE_CUSTOMER_KEY`: Custom type key for Stripe customer ID. Default: `payment-connector-stripe-customer-id`.
-- `CT_CUSTOM_TYPE_SUBSCRIPTION_LINE_ITEM_KEY`: Custom type key for subscription line item. Default: `payment-connector-subscription-line-item-type`.
-- `CT_PRODUCT_TYPE_SUBSCRIPTION_KEY`: Product type key for subscription information. Default: `payment-connector-subscription-information`.
+#### Commercetools Platform
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `CTP_PROJECT_KEY` | Yes | - | Commercetools project key |
+| `CTP_AUTH_URL` | Yes | `https://auth.europe-west1.gcp.commercetools.com` | OAuth 2.0 authentication URL. [Details](https://docs.commercetools.com/tutorials/api-tutorial#authentication) |
+| `CTP_API_URL` | Yes | `https://api.europe-west1.gcp.commercetools.com` | Commercetools API URL |
+| `CTP_SESSION_URL` | Yes | `https://session.europe-west1.gcp.commercetools.com` | Session API URL for enabler/processor communication |
+| `CTP_CHECKOUT_URL` | Yes | - | Checkout API URL |
+| `CTP_JWKS_URL` | Yes | `https://mc-api.europe-west1.gcp.commercetools.com/.well-known/jwks.json` | JSON Web Key Set URL for JWT validation |
+| `CTP_JWT_ISSUER` | Yes | `https://mc-api.europe-west1.gcp.commercetools.com` | JWT issuer for token validation |
+| `CTP_CLIENT_ID` | Yes | - | Client ID with required scopes (secured) |
+| `CTP_CLIENT_SECRET` | Yes | - | Client secret (secured) |
+
+Required API client scopes: `manage_payments`, `manage_orders`, `view_sessions`, `view_api_clients`, `manage_checkout_payment_intents`, `introspect_oauth_tokens`, `manage_types`, `view_types`.
+
+#### Stripe
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `STRIPE_SECRET_KEY` | Yes | - | Server-side secret key (secured). [Restricted key permissions](#3-stripe-account-and-keys) |
+| `STRIPE_PUBLISHABLE_KEY` | Yes | - | Frontend publishable key |
+| `STRIPE_WEBHOOK_ID` | Yes | - | Webhook endpoint identifier (`we_*****`) |
+| `STRIPE_WEBHOOK_SIGNING_SECRET` | Yes | - | Webhook signing secret for HMAC verification (secured) |
+| `STRIPE_CAPTURE_METHOD` | No | `automatic` | `automatic`, `automatic_async`, or `manual`. Must be `manual` for multicapture. |
+| `STRIPE_API_VERSION` | No | `2025-12-15.clover` | Pin to a specific Stripe API version |
+| `MERCHANT_RETURN_URL` | Yes | - | Return URL for [confirmPayment](https://docs.stripe.com/js/payment_intents/confirm_payment). Required for BNPL methods. |
+
+#### Stripe Payment Element Appearance
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `STRIPE_APPEARANCE_PAYMENT_ELEMENT` | No | - | Stringified JSON for Payment Element theming. [Appearance API](https://docs.stripe.com/elements/appearance-api) |
+| `STRIPE_APPEARANCE_EXPRESS_CHECKOUT` | No | - | Stringified JSON for Express Checkout theming. [Appearance API](https://docs.stripe.com/elements/appearance-api) |
+| `STRIPE_LAYOUT` | No | `{"type":"tabs","defaultCollapsed":false}` | Payment Element layout. [Layout options](https://docs.stripe.com/payments/payment-element#layout) |
+| `STRIPE_COLLECT_BILLING_ADDRESS` | Yes | `auto` | Billing address collection: `auto`, `never`, or `if_required`. [Details](https://docs.stripe.com/payments/payment-element/control-billing-details-collection) |
+| `STRIPE_APPLE_PAY_WELL_KNOWN` | No | - | Domain association file URL for [Apple Pay](https://stripe.com/docs/apple-pay/web) |
+| `STRIPE_SAVED_PAYMENT_METHODS_CONFIG` | No | `{"payment_method_save":"disabled"}` | Stringified JSON for saved payment methods. [Customer session features](https://docs.stripe.com/api/customer_sessions/object#customer_session_object-components-payment_element-features) |
+
+#### Subscription Configuration
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `STRIPE_SUBSCRIPTION_PAYMENT_HANDLING` | No | `createOrder` | `createOrder` (new order per payment) or `addPaymentToOrder` (add to existing order) |
+| `STRIPE_SUBSCRIPTION_PRICE_SYNC_ENABLED` | No | `false` | When `true`, prices sync before invoice creation via `invoice.upcoming` webhook. When `false`, prices update after payment for next billing cycle. |
+
+#### Advanced Features
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `STRIPE_ENABLE_MULTI_OPERATIONS` | No | `false` | Enables multicapture and multirefund. Requires multicapture in your Stripe account AND `STRIPE_CAPTURE_METHOD=manual`. [Details](./docs/multiple-refunds-multicapture.md) |
+
+#### Custom Type Keys
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `CT_CUSTOM_TYPE_LAUNCHPAD_PURCHASE_ORDER_KEY` | Yes | `payment-launchpad-purchase-order` | Custom type key for purchase order number |
+| `CT_CUSTOM_TYPE_STRIPE_CUSTOMER_KEY` | Yes | `payment-connector-stripe-customer-id` | Custom type key for Stripe customer ID |
+| `CT_CUSTOM_TYPE_SUBSCRIPTION_LINE_ITEM_KEY` | Yes | `payment-connector-subscription-line-item-type` | Custom type key for subscription line item |
+| `CT_PRODUCT_TYPE_SUBSCRIPTION_KEY` | Yes | `payment-connector-subscription-information` | Product type key for subscription information |
+
+> **Note**: Variables marked "(secured)" are stored as `securedConfiguration` in `connect.yaml` -- encrypted at rest and write-only after deployment.
 
 ## Development
 
@@ -637,3 +453,15 @@ This command would start three services that are required for development.
 1. JWT Server
 2. Enabler
 3. Processor
+
+## Related Documentation
+
+- [SECURITY.md](./SECURITY.md) -- Security policy, shared responsibility model, and vulnerability reporting
+- [CLAUDE.md](./CLAUDE.md) -- Development guidelines and architecture invariants
+- [Processor Documentation](./processor/README.md) -- Detailed processor docs, subscription config, API reference
+- [Enabler Documentation](./enabler/README.md) -- Frontend component integration guide
+- [Changelog](./docs/CHANGELOG.md) -- Release notes and recent updates
+- [Subscription Price Synchronization](./docs/subscription-price-synchronization.md)
+- [Mixed Cart Support](./docs/mixed-cart-support.md)
+- [Multiple Refunds and Multicapture](./docs/multiple-refunds-multicapture.md)
+- [Attribute Name Standardization](./docs/attribute-name-standardization.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,226 @@
+# Security Policy
+
+## Overview
+
+The Stripe Payment Connector for Composable Commerce is a **backend translation layer and frontend component wrapper** that integrates Stripe's payment platform with Commercetools' commerce platform. It runs inside the [Commercetools Connect](https://docs.commercetools.com/connect) managed runtime.
+
+This document describes the connector's security model, shared responsibility boundaries, and how to report vulnerabilities.
+
+## Deployment Model
+
+This connector is designed to run in the **Commercetools Connect runtime**, a managed platform on Google Cloud Platform. It is NOT a standalone application.
+
+```
+Internet
+    │
+    ▼
+┌──────────────────────────────────────┐
+│  Commercetools Connect Runtime       │
+│  (managed platform on GCP)           │
+│                                      │
+│  Provides:                           │
+│  - TLS termination (min TLS 1.2)     │
+│  - HTTPS enforcement (HTTP → 404)    │
+│  - Container isolation               │
+│  - Secrets encryption                │
+│  - Required config enforcement       │
+│  - Pre-deploy SAST/SCA scanning      │
+│  - Autoscaling                       │
+│  - Request timeout (5 min)           │
+│                                      │
+│  ┌────────────────────────────────┐  │
+│  │  This Connector                │  │
+│  │  (processor service +          │  │
+│  │   enabler static assets)       │  │
+│  └────────────────────────────────┘  │
+└──────────────────────────────────────┘
+```
+
+Users install this connector via the Commercetools Connect marketplace and configure it through environment variables. Users do NOT manage infrastructure, networking, or TLS.
+
+Users may also fork this repository and import it as a **custom** connect application. In that case, the same runtime protections apply, but code-level modifications are the user's responsibility.
+
+## Shared Responsibility Model
+
+### Commercetools Connect Runtime is responsible for:
+- TLS termination and HTTPS enforcement
+- Container isolation between applications
+- Encrypting secrets stored in `securedConfiguration`
+- Enforcing `required: true` configuration fields at deployment time
+- Pre-deployment static analysis (SAST) and software composition analysis (SCA)
+- Autoscaling and availability
+- Request timeout enforcement (5 minutes)
+
+### This connector is responsible for:
+- Authenticating and authorizing every request via JWT, OAuth2, or Stripe webhook signature
+- Validating all input (request bodies, URL parameters, query strings)
+- Sanitizing error responses (not leaking internal details)
+- Translating between Stripe and Commercetools payment schemas correctly
+- Handling Stripe webhook events idempotently
+- Managing Stripe customer, payment, and subscription lifecycle
+
+### The merchant (user) is responsible for:
+- Providing valid Stripe API keys and webhook signing secrets
+- Configuring the Stripe webhook endpoint to point to the connector
+- Building their storefront frontend and checkout flow
+- Implementing business logic (fulfillment, refund policies, fraud rules)
+- Restricting Stripe API key permissions to the minimum required scopes
+- Monitoring payment operations and handling disputes
+
+## Authentication Model
+
+The connector uses different authentication mechanisms depending on the endpoint category:
+
+### Frontend-facing endpoints (Session JWT)
+Endpoints called by the merchant's storefront via the enabler component:
+- `GET/POST /payments` -- Create payment intent
+- `POST /confirmPayments/:id` -- Confirm payment
+- `GET /config-element/:payment` -- Get UI configuration
+- `POST /setupIntent` -- Create setup intent
+- `POST /subscription` -- Create subscription
+- `POST /shipping-methods` -- Get shipping methods
+- `GET /customer/session` -- Get customer session
+
+These are protected by `SessionHeaderAuthenticationHook` from the [connect-payments-sdk](https://github.com/commercetools/connect-payments-sdk), which validates a session JWT issued by Commercetools Checkout.
+
+### Backend/service-to-service endpoints (OAuth2 + Authorization)
+Endpoints called by merchant backend systems or Commercetools Checkout:
+- `POST /payment-intents/:id` -- Capture, refund, or cancel payment
+- `POST /subscription-api/:customerId` -- Update subscription
+- `DELETE /subscription-api/:customerId/:subscriptionId` -- Cancel subscription
+
+These are protected by `Oauth2AuthenticationHook` and `AuthorityAuthorizationHook`, which validate OAuth2 tokens and check required scopes (`manage_project`, `manage_checkout_payment_intents`).
+
+### Webhook endpoint (Stripe HMAC signature)
+- `POST /stripe/webhooks` -- Receive Stripe webhook events
+
+This endpoint uses **Stripe's prescribed webhook verification pattern**:
+
+1. **Pre-filter** (`StripeHeaderAuthHook`): Rejects requests that do not include a `stripe-signature` header. This is a lightweight gate that filters out obviously non-Stripe traffic before body processing.
+
+2. **Cryptographic verification** (`stripe.webhooks.constructEvent()`): The sole security control for webhooks. It:
+   - Recomputes HMAC-SHA256 over `timestamp + "." + rawBody` using the webhook signing secret (`whsec_...`)
+   - Compares the computed signature against the one in the `stripe-signature` header
+   - Validates the timestamp (300-second tolerance) to prevent replay attacks
+   - Throws if any check fails, and the handler returns HTTP 400
+
+   This is [Stripe's officially recommended approach](https://docs.stripe.com/webhooks#verify-official-libraries). The signing secret is a shared secret between Stripe and the merchant, established during webhook endpoint registration. Stripe does not use API keys or OAuth for webhooks -- the HMAC signature scheme is the entire trust model.
+
+3. **Raw body preservation**: The `fastify-raw-body` plugin is configured specifically for the webhook route to preserve the exact bytes Stripe sent. This is required because `constructEvent()` validates against the original bytes -- if the body were parsed as JSON first and re-serialized, the signature would fail.
+
+> **Note for security reviewers:** The `StripeHeaderAuthHook` is intentionally a presence check only. It is NOT the security control -- `constructEvent()` is. This is by design per Stripe's webhook verification documentation.
+
+## CORS Policy
+
+The connector sets `origin: '*'` for CORS. This is intentional for the following reasons:
+
+1. **Composable commerce model**: The enabler component is designed to be embedded in any merchant's storefront, on any domain. The connector cannot predict merchant domains at build time.
+
+2. **CORS is not the security boundary**: Every endpoint is independently authenticated via session JWT, OAuth2, or Stripe webhook signature. CORS is a browser-level mechanism; server-to-server requests bypass it entirely. The authentication layer is the actual security control.
+
+3. **No credentials in CORS**: The connector does not use cookies or browser-stored credentials for authentication. All auth is via explicit headers (`Authorization`, `X-Session-ID`), which requires the caller to already possess valid tokens.
+
+Merchants who want to restrict CORS origins for defense-in-depth can fork the connector and modify the CORS configuration in `processor/src/server/server.ts`.
+
+## Configuration Security
+
+### Secret management
+
+Secrets are declared as `securedConfiguration` in `connect.yaml` and are:
+- Encrypted at rest by the Connect runtime
+- Write-only (cannot be retrieved or viewed after being set)
+- Injected as environment variables at container startup
+- Enforced as `required: true` -- deployment fails if not provided
+
+The following are stored as secured configuration:
+| Variable | Purpose |
+|---|---|
+| `CTP_CLIENT_ID` | Commercetools API client ID |
+| `CTP_CLIENT_SECRET` | Commercetools API client secret |
+| `STRIPE_SECRET_KEY` | Stripe server-side secret key |
+| `STRIPE_WEBHOOK_SIGNING_SECRET` | Webhook HMAC signing secret |
+
+### Stripe API key permissions
+
+When using restricted Stripe API keys, the minimum required permissions are:
+- PaymentIntents: Write
+- Refunds: Write
+- Customer: Write
+- CustomerSession: Write
+- Webhook Endpoints: Write
+- Subscriptions: Write
+
+We recommend using restricted keys scoped to only these permissions rather than using the full secret key.
+
+## Data Flow Trust Boundaries
+
+```
+┌─────────────┐     Session JWT      ┌──────────────────┐    Stripe SDK     ┌─────────────┐
+│  Merchant's  │ ──────────────────► │  This Connector   │ ───────────────► │   Stripe     │
+│  Storefront  │ ◄────────────────── │  (processor)      │ ◄─────────────── │   API        │
+│  (browser)   │   Payment config    │                   │   PaymentIntent  │              │
+└─────────────┘                      │                   │                  └──────┬───────┘
+                                     │                   │                         │
+                                     │                   │   Webhook + HMAC sig    │
+                                     │                   │ ◄───────────────────────┘
+                                     │                   │
+                                     │                   │    CT SDK          ┌─────────────┐
+                                     │                   │ ───────────────► │ Commercetools │
+                                     │                   │ ◄─────────────── │     API       │
+                                     └──────────────────┘   Payment/Order   └──────────────┘
+```
+
+**Trust boundaries:**
+1. **Browser → Connector**: Untrusted. Every request must carry a valid session JWT. Input is validated via Fastify schemas.
+2. **Connector → Stripe**: Trusted. Uses Stripe SDK with the merchant's secret key over TLS.
+3. **Stripe → Connector (webhooks)**: Semi-trusted. Every event is cryptographically verified via `constructEvent()`.
+4. **Connector → Commercetools**: Trusted. Uses CT SDK with OAuth2 client credentials over TLS.
+
+## Reporting Vulnerabilities
+
+If you discover a security vulnerability in this connector, please report it responsibly:
+
+1. **Do NOT open a public GitHub issue** for security vulnerabilities.
+2. Email security reports to the repository maintainers with:
+   - Description of the vulnerability
+   - Steps to reproduce
+   - Potential impact assessment
+   - Suggested fix (if any)
+3. Allow reasonable time for the issue to be addressed before public disclosure.
+
+### Out of scope for vulnerability reports
+
+The following are **by design** and will be triaged as informational:
+
+- **`origin: '*'` CORS configuration**: Intentional for composable commerce. See [CORS Policy](#cors-policy).
+- **`StripeHeaderAuthHook` being a presence-only check**: Intentional. `constructEvent()` is the cryptographic guard. See [Webhook endpoint](#webhook-endpoint-stripe-hmac-signature).
+- **The connector accepting connections from any IP**: The Connect runtime handles network-level controls. The connector authenticates at the application layer.
+- **Missing WAF or DDoS protection at the application level**: This is the responsibility of the Connect runtime infrastructure (GCP baseline).
+- **Commercetools SDK or Stripe SDK vulnerabilities**: Report these to their respective maintainers.
+
+### In scope for vulnerability reports
+
+- Input validation bypasses that lead to unauthorized actions
+- Authentication or authorization bypasses
+- Information disclosure (error messages, logs, or responses leaking sensitive data)
+- Business logic flaws (e.g., payment amount manipulation, unauthorized refunds)
+- Injection vulnerabilities in any form
+- Cryptographic weaknesses in the connector's own code (not Stripe's SDK)
+
+## Security-Related Configuration
+
+| Variable | Security Relevance | Notes |
+|---|---|---|
+| `STRIPE_SECRET_KEY` | Server-side API authentication | Use restricted keys with minimum scopes |
+| `STRIPE_WEBHOOK_SIGNING_SECRET` | Webhook HMAC verification | Unique per webhook endpoint |
+| `CTP_CLIENT_ID` / `CTP_CLIENT_SECRET` | Commercetools API authentication | Scope to minimum required permissions |
+| `CTP_JWKS_URL` | JWT signature verification | Must point to the correct Commercetools region |
+| `CTP_JWT_ISSUER` | JWT issuer validation | Must match the Commercetools region |
+| `STRIPE_CAPTURE_METHOD` | `manual` vs `automatic` capture | `manual` requires explicit capture call |
+| `STRIPE_ENABLE_MULTI_OPERATIONS` | Multicapture/multirefund | Disabled by default; requires Stripe account support |
+
+## Related Documentation
+
+- [Stripe Webhook Verification](https://docs.stripe.com/webhooks#verify-official-libraries) -- Stripe's official verification documentation
+- [Commercetools Connect Security](https://docs.commercetools.com/connect/concepts) -- Connect runtime security model
+- [connect-payments-sdk](https://github.com/commercetools/connect-payments-sdk) -- Authentication hooks documentation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -110,6 +110,16 @@ This endpoint uses **Stripe's prescribed webhook verification pattern**:
 
 > **Note for security reviewers:** The `StripeHeaderAuthHook` is intentionally a presence check only. It is NOT the security control -- `constructEvent()` is. This is by design per Stripe's webhook verification documentation.
 
+## Payment Flow Integrity
+
+The connector uses [Stripe's deferred intent pattern](https://docs.stripe.com/payments/payment-element/deferred-intent) -- no PaymentIntent exists until the customer submits payment. Key integrity properties:
+
+- **Cart freeze guarantees amount consistency.** When a PI is created, the cart is frozen immediately after. A frozen Commercetools cart rejects all modification actions. This ensures `PI amount === cart total` for the lifetime of the payment flow.
+- **Express Checkout shipping routes are component-specific lifecycle handlers**, not general-purpose cart management APIs. `GET /shipping-methods/remove` handles Express Checkout cancellation (user dismisses Apple Pay / Google Pay sheet). In the deferred intent pattern, no PI exists at cancellation time -- PI creation only happens on the `confirm` event, which is mutually exclusive with `cancel`.
+- **Amount validation is intentionally not hardcoded** in the webhook handler. In automatic capture, cart freeze guarantees the match. In manual capture, multi-capture, and incremental auth, amounts legitimately differ. The webhook handler warns on anomalies (unfrozen cart at `payment_intent.succeeded` time) rather than blocking.
+
+For implementation details, see [CLAUDE.md](./CLAUDE.md#payment-flow-integrity).
+
 ## CORS Policy
 
 The connector sets `origin: '*'` for CORS. This is intentional for the following reasons:
@@ -197,6 +207,9 @@ The following are **by design** and will be triaged as informational:
 - **The connector accepting connections from any IP**: The Connect runtime handles network-level controls. The connector authenticates at the application layer.
 - **Missing WAF or DDoS protection at the application level**: This is the responsibility of the Connect runtime infrastructure (GCP baseline).
 - **Commercetools SDK or Stripe SDK vulnerabilities**: Report these to their respective maintainers.
+- **Express Checkout cancellation unfreezing the cart**: This is the intended behavior. No PI exists at cancellation time in the deferred intent pattern. See [Payment Flow Integrity](#payment-flow-integrity).
+- **No hard amount validation in the webhook handler**: Intentional. Cart freeze guarantees consistency for automatic capture. Manual/multi-capture flows require amount flexibility. See [Payment Flow Integrity](#payment-flow-integrity).
+- **Exploits that chain routes from different checkout components** (e.g., Payment Element PI creation + Express Checkout cancellation): These routes serve different components with different lifecycles. The connector is a composable building block -- the merchant's storefront controls which routes are called and in what sequence. PoCs that call APIs directly or mix component flows do not reflect real-world usage.
 
 ### In scope for vulnerability reports
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -202,21 +202,29 @@ If you discover a security vulnerability in this connector, please report it res
 
 The following are **by design** and will be triaged as informational:
 
+**Infrastructure and runtime:**
 - **`origin: '*'` CORS configuration**: Intentional for composable commerce. See [CORS Policy](#cors-policy).
 - **`StripeHeaderAuthHook` being a presence-only check**: Intentional. `constructEvent()` is the cryptographic guard. See [Webhook endpoint](#webhook-endpoint-stripe-hmac-signature).
 - **The connector accepting connections from any IP**: The Connect runtime handles network-level controls. The connector authenticates at the application layer.
 - **Missing WAF or DDoS protection at the application level**: This is the responsibility of the Connect runtime infrastructure (GCP baseline).
 - **Commercetools SDK or Stripe SDK vulnerabilities**: Report these to their respective maintainers.
+
+**Payment flow design:**
 - **Express Checkout cancellation unfreezing the cart**: This is the intended behavior. No PI exists at cancellation time in the deferred intent pattern. See [Payment Flow Integrity](#payment-flow-integrity).
 - **No hard amount validation in the webhook handler**: Intentional. Cart freeze guarantees consistency for automatic capture. Manual/multi-capture flows require amount flexibility. See [Payment Flow Integrity](#payment-flow-integrity).
-- **Exploits that chain routes from different checkout components** (e.g., Payment Element PI creation + Express Checkout cancellation): These routes serve different components with different lifecycles. The connector is a composable building block -- the merchant's storefront controls which routes are called and in what sequence. PoCs that call APIs directly or mix component flows do not reflect real-world usage.
+- **Exploits that chain routes from different checkout components** (e.g., Payment Element PI creation + Express Checkout cancellation): These routes serve different components with different lifecycles. The connector is a composable building block -- the merchant's storefront controls which routes are called and in what sequence.
+
+**PoC methodology:**
+- **PoCs that require Stripe secret key (`sk_*`) or Commercetools admin credentials**: These are server-side secrets that customers do not possess. Exploits requiring them demonstrate Stripe/CT API access, not a connector vulnerability.
+- **PoCs that bypass the connector by calling Stripe or Commercetools APIs directly** rather than through the connector's routes: The connector's security model applies to its own endpoints. Direct API calls to Stripe or Commercetools are outside the connector's control and are governed by those platforms' own access controls.
+- **State manipulation that requires direct Commercetools cart/order API access** (e.g., modifying a frozen cart, creating orders, updating payments) outside the connector's routes: The connector does not own or secure the Commercetools API surface.
 
 ### In scope for vulnerability reports
 
-- Input validation bypasses that lead to unauthorized actions
-- Authentication or authorization bypasses
+- Authentication or authorization bypasses on the connector's own routes
+- Business logic flaws **within the connector's own payment flows** (e.g., incorrect amount calculation from cart data, refund exceeding charged amount, transaction state corruption during webhook processing)
+- Input validation bypasses on the connector's routes that lead to unauthorized actions
 - Information disclosure (error messages, logs, or responses leaking sensitive data)
-- Business logic flaws (e.g., payment amount manipulation, unauthorized refunds)
 - Injection vulnerabilities in any form
 - Cryptographic weaknesses in the connector's own code (not Stripe's SDK)
 


### PR DESCRIPTION
## Summary
- Adds `SECURITY.md` with shared responsibility model, authentication documentation, CORS rationale, threat model, and vulnerability reporting guidelines
- Adds `CLAUDE.md` with architecture invariants, security rules, input validation requirements, and development patterns for AI-assisted and contributor development
- Cleans up `README.md`: removes changelog content (belongs in docs/CHANGELOG.md), consolidates triple-duplicated env var documentation into clean tables, fixes copy-paste error ("tax integration"), adds Related Documentation section
- Adds `docs/security-findings.md` to `.gitignore` (internal-only security audit document)

## Context
These grounding documents establish a security baseline for the connector, clarify what is by-design vs. what needs fixing, and reduce noise from white hat security reports by documenting the shared responsibility model between the Commercetools Connect runtime, this connector, and the merchant.

## Test plan
- [ ] Verify all links in SECURITY.md, CLAUDE.md, and README.md resolve correctly
- [ ] Verify `docs/security-findings.md` is not included in the commit (gitignored)
- [ ] Review SECURITY.md "out of scope" section covers known by-design patterns
- [ ] Review README config tables match `connect.yaml` source of truth