### PR TITLE
fix(processor): improve subscription order creation, payment states, and security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,12 +5,23 @@
 # MCP (Model Context Protocol) configuration and data
 .mcp/
 .DS_Store
+.mcp.json
+
+# Playwright MCP
+.playwright-profile/
+.playwright-mcp/
 
 #Context documentation
 docs/context7-libraries
 context
-CLAUDE.md
 context7-config.json
 
 # Connect CLI generated files
 .connect
+
+#Calude and Ralph pipelines
+.claude
+CLAUDE.md
+ralph.sh
+*_prd.json
+*_progress.txt

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## Latest
 
+### Subscription Order Creation Improvements
+
+**Added:**
+- **`OrderPaymentState` enum**: Introduced `Paid` and `Failed` states to represent the CT order payment outcome per event type. Failed subscription events now create orders with `paymentState: Failed` instead of `Paid`.
+- **Shared `createSubscriptionOrderFromCart` helper**: Consolidates the address-update + order-creation tail block that was duplicated across `processSubscriptionEventPaid`, `processSubscriptionEventCharged`, and `processSubscriptionEventFailed`.
+- **Race condition handling**: `createSubscriptionOrderFromCart` catches `ConcurrentModification` / `409` version-conflict errors and skips gracefully, preventing duplicate order creation when `invoice.paid` and `charge.succeeded` fire in quick succession.
+- **Unfrozen cart warning**: Logs a warning when a subscription order is processed for a cart that was not frozen, indicating the payment may not have originated from this connector.
+
+**Changed:**
+- **Config-based branching in `processSubscriptionEventCharged`**: Recurring `charge.succeeded` events now respect the `subscriptionPaymentHandling` config (`createOrder` vs. `addToExisting`) through a new `handleRecurringChargeOrder` private method, consistent with how `invoice.paid` already worked.
+- **`handleSubscriptionPaymentCreateNewOrder`**: Now accepts an optional `paymentState` parameter (defaults to `Paid`) passed through to order creation.
+- **`createOrderFromCart`**: Now accepts an optional `paymentState` parameter (defaults to `Paid`) instead of hardcoding `'Paid'`.
+- **`StripePaymentService.createOrder`**: Forwards `paymentState` to `createOrderFromCart`.
+
+**Refactored:**
+- Extracted `handleRecurringChargeOrder`, `handleFailedEventOrder`, and `resolveFailedPayment` private methods to reduce cognitive complexity in `processSubscriptionEventCharged` and `processSubscriptionEventFailed`.
+- Extracted `hasCompleteAddress`, `unfreezeCartIfNeeded`, and `refreezeCart` private methods from `updateCartAddress` to reduce cognitive complexity and improve readability.
+- Fixed a log template string bug in `processSubscriptionEventCharged` where `updatedPayment.version` was not interpolated.
+- Removed unused `Stripe` import from `ct-payment-creation.service.ts`.
+
+**Tests:**
+- Added `stripe-subscription.service.payment.spec.ts` with coverage for: race conditions, cart state validation (`Ordered` guard), payment state propagation (`Paid` / `Failed`), config-based branching, and unfrozen cart warning.
+
+**Security:**
+- Processor: resolved `brace-expansion` vulnerability (CVE: GHSA-f886-m6hf-6m8v) by adding an `overrides` entry pinning `brace-expansion` to `2.0.3`.
+- Enabler: updated `vite` to `^7.3.2` to address known vulnerabilities.
+
+---
+
 ### Cart Freezing and Unfreezing for Express Checkout
 
 **Added:**

--- a/enabler/package-lock.json
+++ b/enabler/package-lock.json
@@ -22,7 +22,7 @@
         "sass": "1.96.0",
         "ts-jest": "^29.4.6",
         "typescript": "5.9.3",
-        "vite": "7.2.7",
+        "vite": "^7.3.2",
         "vite-plugin-css-injected-by-js": "3.5.2"
       }
     },
@@ -3084,9 +3084,10 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4003,10 +4004,11 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -4033,9 +4035,9 @@
       "dev": true
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4928,9 +4930,9 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5619,10 +5621,11 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -6338,10 +6341,11 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -6688,12 +6692,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.2.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.7.tgz",
-      "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.25.0",
+        "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
@@ -6789,9 +6794,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/enabler/package.json
+++ b/enabler/package.json
@@ -26,7 +26,7 @@
     "sass": "1.96.0",
     "ts-jest": "^29.4.6",
     "typescript": "5.9.3",
-    "vite": "7.2.7",
+    "vite": "^7.3.2",
     "vite-plugin-css-injected-by-js": "3.5.2"
   },
   "overrides": {

--- a/processor/package-lock.json
+++ b/processor/package-lock.json
@@ -806,21 +806,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/config-array/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.6.tgz",
@@ -881,21 +866,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
@@ -1797,21 +1767,6 @@
         }
       }
     },
-    "node_modules/@jest/reporters/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/@jest/reporters/node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -2619,21 +2574,6 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.6.tgz",
@@ -3368,6 +3308,12 @@
         "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -3406,6 +3352,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -4492,21 +4447,6 @@
         "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
       }
     },
-    "node_modules/eslint-plugin-import/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -4648,21 +4588,6 @@
       },
       "funding": {
         "url": "https://eslint.org/donate"
-      }
-    },
-    "node_modules/eslint/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
@@ -5025,9 +4950,9 @@
       ]
     },
     "node_modules/fastify": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.2.tgz",
-      "integrity": "sha512-lZmt3navvZG915IE+f7/TIVamxIwmBd+OMB+O9WBzcpIwOo6F0LTh0sluoMFk5VkrKTvvrwIaoJPkir4Z+jtAg==",
+      "version": "5.8.4",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.4.tgz",
+      "integrity": "sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==",
       "funding": [
         {
           "type": "github",
@@ -5038,6 +4963,7 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@fastify/ajv-compiler": "^4.0.5",
         "@fastify/error": "^4.0.0",
@@ -5204,10 +5130,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fluent-schema": {
       "version": "1.1.0",
@@ -5462,19 +5389,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/glob/node_modules/minimatch": {
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.6.tgz",
@@ -5545,10 +5459,11 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -6487,21 +6402,6 @@
         }
       }
     },
-    "node_modules/jest-config/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/jest-config/node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -6845,21 +6745,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-runtime/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/jest-runtime/node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -6982,10 +6867,11 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -7318,9 +7204,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -7697,21 +7584,6 @@
         "url": "https://opencollective.com/nodemon"
       }
     },
-    "node_modules/nodemon/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/nodemon/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -8081,10 +7953,11 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -9212,21 +9085,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/test-exclude/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/test-exclude/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -9313,10 +9171,11 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -9722,9 +9581,10 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
-      "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
       }

--- a/processor/package.json
+++ b/processor/package.json
@@ -69,6 +69,7 @@
     "jws": "3.2.3",
     "qs": "6.14.1",
     "lodash": "^4.17.22",
-    "minimatch": "8.0.6"
+    "minimatch": "8.0.6",
+    "brace-expansion": "2.0.3"
   }
 }

--- a/processor/src/services/commerce-tools/order-client.ts
+++ b/processor/src/services/commerce-tools/order-client.ts
@@ -1,9 +1,10 @@
 import { Cart, Order } from '@commercetools/platform-sdk';
 import { paymentSDK } from '../../payment-sdk';
+import { OrderPaymentState } from '../types/stripe-payment.type';
 
 const apiClient = paymentSDK.ctAPI.client;
 
-export const createOrderFromCart = async (cart: Cart) => {
+export const createOrderFromCart = async (cart: Cart, paymentState: OrderPaymentState = OrderPaymentState.PAID) => {
   const latestCart = await paymentSDK.ctCartService.getCart({ id: cart.id });
 
   const res = await apiClient
@@ -17,7 +18,7 @@ export const createOrderFromCart = async (cart: Cart) => {
         shipmentState: 'Pending',
         orderState: 'Open',
         version: latestCart.version,
-        paymentState: 'Paid',
+        paymentState,
       },
     })
     .execute();

--- a/processor/src/services/ct-payment-creation.service.ts
+++ b/processor/src/services/ct-payment-creation.service.ts
@@ -14,7 +14,6 @@ import {
   METADATA_PROJECT_KEY_FIELD,
   METADATA_SUBSCRIPTION_ID_FIELD,
 } from '../constants';
-import Stripe from 'stripe';
 import {
   HandleCtPaymentCreationProps,
   HandlePaymentSubscriptionProps,

--- a/processor/src/services/stripe-payment.service.ts
+++ b/processor/src/services/stripe-payment.service.ts
@@ -433,7 +433,7 @@ export class StripePaymentService extends AbstractPaymentService {
         // Tax calculation integration
         ...(hasTaxCalculations && {
           hasTaxCalculations,
-          taxCalculationCount
+          taxCalculationCount,
         }),
         // Log if frontend options were applied
         ...(options?.paymentMethodOptions && {
@@ -482,7 +482,7 @@ export class StripePaymentService extends AbstractPaymentService {
   /**
    * Merges backend default payment method options with frontend provided options.
    * Frontend options take priority over backend defaults for the same payment method.
-   * 
+   *
    * @param frontendOptions - Payment method options provided from the frontend
    * @returns Merged payment method options
    */
@@ -524,12 +524,15 @@ export class StripePaymentService extends AbstractPaymentService {
       const ctPayment = await this.ctPaymentService.getPayment({ id: paymentReference });
 
       if (ctPayment.interfaceId !== paymentIntentId) {
-        log.error('PaymentIntent ID does not match CT Payment interfaceId — rejecting update to avoid wrong PI to wrong CT payment.', {
-          paymentReference,
-          requestPaymentIntentId: paymentIntentId,
-          ctPaymentInterfaceId: ctPayment.interfaceId,
-          ctCartId: ctCart.id,
-        });
+        log.error(
+          'PaymentIntent ID does not match CT Payment interfaceId — rejecting update to avoid wrong PI to wrong CT payment.',
+          {
+            paymentReference,
+            requestPaymentIntentId: paymentIntentId,
+            ctPaymentInterfaceId: ctPayment.interfaceId,
+            ctCartId: ctCart.id,
+          },
+        );
         throw new Error(
           `PaymentIntent mismatch: request paymentIntentId (${paymentIntentId}) does not match CT payment interfaceId (${ctPayment.interfaceId})`,
         );
@@ -748,8 +751,7 @@ export class StripePaymentService extends AbstractPaymentService {
           cartCurrency: ctCart.totalPrice?.currencyCode,
           stripeAmountReceived: paymentIntent.amount_received,
           stripeCurrency: paymentIntent.currency,
-          amountMismatch:
-            paymentIntent.amount_received !== ctCart.totalPrice?.centAmount,
+          amountMismatch: paymentIntent.amount_received !== ctCart.totalPrice?.centAmount,
         },
       );
     }
@@ -928,8 +930,8 @@ export class StripePaymentService extends AbstractPaymentService {
     }
   }
 
-  public async createOrder({ cart, subscriptionId, paymentIntentId }: CreateOrderProps) {
-    const order = await createOrderFromCart(cart);
+  public async createOrder({ cart, subscriptionId, paymentIntentId, paymentState }: CreateOrderProps) {
+    const order = await createOrderFromCart(cart, paymentState);
     log.info('Order created successfully', {
       ctOrderId: order.id,
       ctCartId: cart.id,
@@ -982,44 +984,12 @@ export class StripePaymentService extends AbstractPaymentService {
     const addressSource = shipping || billing_details;
     const address = addressSource?.address;
 
-    // Verify if Stripe has a complete and valid address
-    const hasCompleteStripeAddress = !!(
-      address?.country &&
-      address?.state &&
-      address?.city &&
-      address?.postal_code &&
-      address?.line1
-    );
-
-    // If Stripe does not have a complete address, keep the cart's address
-    if (!hasCompleteStripeAddress) {
-      // If the cart already has an address, do not overwrite it with incomplete data
-      if (ctCart.shippingAddress?.country) {
-        return ctCart;
-      }
-      // If the cart also does not have an address, do nothing (avoid using mocks)
+    if (!this.hasCompleteAddress(address)) {
       return ctCart;
     }
 
-    // Unfreeze cart temporarily if frozen (for successful payment address update)
-    let cartToUpdate = ctCart;
+    const cartToUpdate = await this.unfreezeCartIfNeeded(ctCart);
     const wasFrozen = isCartFrozen(ctCart);
-
-    if (wasFrozen) {
-      try {
-        cartToUpdate = await unfreezeCart(ctCart);
-        log.info(`Cart temporarily unfrozen for address update from successful payment.`, {
-          ctCartId: cartToUpdate.id,
-        });
-      } catch (error) {
-        log.error(`Error unfreezing cart for address update.`, {
-          error,
-          ctCartId: ctCart.id,
-        });
-        // If unfreeze fails, try to update anyway (might work if cart was already unfrozen)
-        cartToUpdate = ctCart;
-      }
-    }
 
     // Stripe has complete address → update the cart
     const actions: CartUpdateAction[] = [
@@ -1027,36 +997,53 @@ export class StripePaymentService extends AbstractPaymentService {
         action: 'setShippingAddress',
         address: {
           key: addressSource?.name ?? undefined,
-          country: address.country!,
-          city: address.city ?? undefined,
-          postalCode: address.postal_code ?? undefined,
-          state: address.state ?? undefined,
-          streetName: address.line1 ?? undefined,
-          streetNumber: address.line2 ?? undefined,
+          country: address!.country!,
+          city: address!.city ?? undefined,
+          postalCode: address!.postal_code ?? undefined,
+          state: address!.state ?? undefined,
+          streetName: address!.line1 ?? undefined,
+          streetNumber: address!.line2 ?? undefined,
         },
       },
     ];
 
     const updatedCart = await updateCartById(cartToUpdate, actions);
 
-    // Re-freeze cart if it was frozen before
-    if (wasFrozen) {
-      try {
-        const reFrozenCart = await freezeCart(updatedCart);
-        log.info(`Cart re-frozen after address update from successful payment.`, {
-          ctCartId: reFrozenCart.id,
-        });
-        return reFrozenCart;
-      } catch (error) {
-        log.error(`Error re-freezing cart after address update.`, {
-          error,
-          ctCartId: updatedCart.id,
-        });
-        // Return updated cart even if re-freeze fails
-        return updatedCart;
-      }
-    }
+    return wasFrozen ? this.refreezeCart(updatedCart) : updatedCart;
+  }
 
-    return updatedCart;
+  private hasCompleteAddress(
+    address: Stripe.Address | Stripe.PaymentIntent.Shipping['address'] | null | undefined,
+  ): boolean {
+    return !!(address?.country && address?.state && address?.city && address?.postal_code && address?.line1);
+  }
+
+  private async unfreezeCartIfNeeded(cart: Cart): Promise<Cart> {
+    if (!isCartFrozen(cart)) {
+      return cart;
+    }
+    try {
+      const unfrozenCart = await unfreezeCart(cart);
+      log.info(`Cart temporarily unfrozen for address update from successful payment.`, {
+        ctCartId: unfrozenCart.id,
+      });
+      return unfrozenCart;
+    } catch (error) {
+      log.error(`Error unfreezing cart for address update.`, { error, ctCartId: cart.id });
+      return cart;
+    }
+  }
+
+  private async refreezeCart(cart: Cart): Promise<Cart> {
+    try {
+      const reFrozenCart = await freezeCart(cart);
+      log.info(`Cart re-frozen after address update from successful payment.`, {
+        ctCartId: reFrozenCart.id,
+      });
+      return reFrozenCart;
+    } catch (error) {
+      log.error(`Error re-freezing cart after address update.`, { error, ctCartId: cart.id });
+      return cart;
+    }
   }
 }

--- a/processor/src/services/stripe-subscription.service.ts
+++ b/processor/src/services/stripe-subscription.service.ts
@@ -57,7 +57,13 @@ import {
 } from '../custom-types/custom-types';
 import { getSubscriptionAttributes, getSubscriptionUpdateAttributes } from '../mappers/subscription-mapper';
 import { CtPaymentCreationService } from './ct-payment-creation.service';
-import { createCartFromDraft, getCartExpanded, updateCartById, freezeCart } from './commerce-tools/cart-client';
+import {
+  createCartFromDraft,
+  getCartExpanded,
+  updateCartById,
+  freezeCart,
+  isCartFrozen,
+} from './commerce-tools/cart-client';
 import { getCustomFieldUpdateActions } from './commerce-tools/custom-type-helper';
 import {
   METADATA_CART_ID_FIELD,
@@ -76,7 +82,7 @@ import { getProductById, getProductMasterPrice, getPriceFromProduct } from './co
 import { createCartWithProduct } from './commerce-tools/cart-client';
 import { SubscriptionEventConverter } from './converters/subscriptionEventConverter';
 import { PaymentTransactions } from '../dtos/operations/payment-intents.dto';
-import { PaymentStatus, StripeEventUpdatePayment } from './types/stripe-payment.type';
+import { OrderPaymentState, PaymentStatus, StripeEventUpdatePayment } from './types/stripe-payment.type';
 
 const stripe = stripeApi();
 
@@ -334,13 +340,13 @@ export class StripeSubscriptionService {
 
   public validateSubscription(subscription: Stripe.Subscription) {
     const latestInvoice = subscription.latest_invoice as StripeInvoiceExpanded | string | null;
-    
+
     if (typeof latestInvoice === 'string' || !latestInvoice) {
       throw new Error('Failed to create Subscription, missing Payment Intent.');
     }
 
     const paymentIntent = latestInvoice.payment_intent as Stripe.PaymentIntent | string | null;
-    
+
     if (typeof paymentIntent === 'string' || !paymentIntent?.client_secret) {
       throw new Error('Failed to create Subscription, missing Payment Intent.');
     }
@@ -996,11 +1002,7 @@ export class StripeSubscriptionService {
    * @returns The product variant at the specified position
    * @throws Error if no variant is found at the specified position
    */
-  private getVariantByPosition(
-    product: Product,
-    variantPosition: number,
-    productId: string,
-  ): ProductVariant {
+  private getVariantByPosition(product: Product, variantPosition: number, productId: string): ProductVariant {
     let variant;
     if (variantPosition === 1) {
       variant = product.masterData?.current?.masterVariant;
@@ -1194,19 +1196,18 @@ export class StripeSubscriptionService {
         });
       }
 
-      const cart = await this.ctCartService.getCartByPaymentId({ paymentId: payment.id });
-      if (cart.cartState !== 'Ordered') {
-        log.info('Updating cart address after processing the notification', {
-          ctCartId: cart.id,
+      if (isPaymentChargePending || isPaymentFailed) {
+        await this.createSubscriptionOrderFromCart({
+          paymentId: payment.id,
+          charge: invoiceExpanded.charge as Stripe.Charge,
+          paymentIntentId: updateData.pspReference,
           invoiceId: invoiceExpanded.id,
+          paymentState: OrderPaymentState.PAID,
         });
-        const updatedCart = await this.paymentService.updateCartAddress(invoiceExpanded.charge as Stripe.Charge, cart);
-        await this.paymentService.createOrder({ cart: updatedCart, paymentIntentId: updateData.pspReference });
       }
     } catch (e) {
-      log.error(
-        `Error processing Subscription processSubscriptionEventPaid notification: ${JSON.stringify(e, null, 2)}`,
-      );
+      const errorMessage = e instanceof Error ? e.message : JSON.stringify(e);
+      log.error(`Error processing Subscription processSubscriptionEventPaid notification: ${errorMessage}`);
       return;
     }
   }
@@ -1238,7 +1239,12 @@ export class StripeSubscriptionService {
         log.info(
           `Creating new order for subscription payment ${updateData.id} (config: ${config.subscriptionPaymentHandling})`,
         );
-        updateData.id = await this.handleSubscriptionPaymentCreateNewOrder(subscription, invoiceExpanded, updateData);
+        updateData.id = await this.handleSubscriptionPaymentCreateNewOrder(
+          subscription,
+          invoiceExpanded,
+          updateData,
+          OrderPaymentState.PAID,
+        );
         log.info(`New order created successfully for subscription payment ${updateData.id}`);
       } else {
         log.info(
@@ -1256,6 +1262,81 @@ export class StripeSubscriptionService {
       }
     }
     return true;
+  }
+
+  /**
+   * Shared method for subscription order creation that replaces duplicated tail blocks.
+   * Checks cart state, warns on unfrozen carts, updates address, and creates order with
+   * a defensive try/catch for version-conflict race conditions (e.g., invoice.paid vs charge.succeeded).
+   * @param params.paymentId - The commercetools payment ID to look up the cart
+   * @param params.charge - The Stripe charge for address update
+   * @param params.paymentIntentId - The PSP reference for the order
+   * @param params.invoiceId - The Stripe invoice ID (for logging)
+   * @param params.paymentState - The payment state for the order
+   * @returns True if order was created, false if skipped or failed gracefully
+   */
+  private async createSubscriptionOrderFromCart(params: {
+    paymentId: string;
+    charge: Stripe.Charge;
+    paymentIntentId: string;
+    invoiceId: string;
+    paymentState?: OrderPaymentState;
+  }): Promise<boolean> {
+    const { paymentId, charge, paymentIntentId, invoiceId, paymentState = OrderPaymentState.PAID } = params;
+
+    const cart = await this.ctCartService.getCartByPaymentId({ paymentId });
+    if (cart.cartState === 'Ordered') {
+      log.info('Cart already ordered, skipping subscription order creation', {
+        ctCartId: cart.id,
+        invoiceId,
+      });
+      return false;
+    }
+
+    if (!isCartFrozen(cart)) {
+      log.warn(
+        'Processing subscription order for unfrozen cart — payment may not have originated from this connector.',
+        {
+          ctCartId: cart.id,
+          paymentId,
+          invoiceId,
+        },
+      );
+    }
+
+    log.info('Updating cart address after processing the notification', {
+      ctCartId: cart.id,
+      invoiceId,
+    });
+
+    const updatedCart = await this.paymentService.updateCartAddress(charge, cart);
+
+    try {
+      await this.paymentService.createOrder({
+        cart: updatedCart,
+        paymentIntentId,
+        paymentState,
+      });
+      return true;
+    } catch (e: unknown) {
+      const errorMessage = e instanceof Error ? e.message : JSON.stringify(e);
+      const isVersionConflict =
+        errorMessage.includes('ConcurrentModification') ||
+        errorMessage.includes('version') ||
+        errorMessage.includes('409');
+      if (isVersionConflict) {
+        log.info(
+          'Subscription order creation skipped due to version conflict (likely race condition with another handler)',
+          {
+            ctCartId: updatedCart.id,
+            invoiceId,
+            error: errorMessage,
+          },
+        );
+        return false;
+      }
+      throw e;
+    }
   }
 
   /**
@@ -1338,7 +1419,7 @@ export class StripeSubscriptionService {
       const invoiceExpanded = await this.paymentCreationService.getStripeInvoiceExpanded(dataInvoiceId);
 
       const subscription = invoiceExpanded.subscription as Stripe.Subscription;
-      const paymentId = subscription.metadata?.[METADATA_PAYMENT_ID_FIELD];
+      const paymentId = await this.resolvePaymentIdFromSubscription(subscription, dataInvoiceId);
       if (!paymentId) {
         log.error(
           `Cannot process invoice with ID: ${invoiceExpanded.id}. Missing payment ID in subscription metadata.`,
@@ -1364,6 +1445,19 @@ export class StripeSubscriptionService {
         isPaymentChargePending,
         payment,
       );
+
+      if (!isPaymentChargePending) {
+        const shouldContinue = await this.handleRecurringChargeOrder(
+          subscription,
+          invoiceExpanded,
+          payment,
+          updateData,
+        );
+        if (!shouldContinue) {
+          return;
+        }
+      }
+
       for (const tx of updateData.transactions) {
         const updatedPayment = await this.ctPaymentService.updatePayment({
           ...updateData,
@@ -1371,29 +1465,68 @@ export class StripeSubscriptionService {
         });
 
         log.info(`Subscription payment updated after processing the notification ${updatedPayment.id}
-          paymentId:  ${updatedPayment.id}
-          version: updatedPayment.version}
+          paymentId: ${updatedPayment.id}
+          version: ${updatedPayment.version}
           pspReference: ${updateData.pspReference}
           paymentMethod: ${updateData.paymentMethod}
           transaction: ${JSON.stringify(tx)}
         `);
       }
 
-      const cart = await this.ctCartService.getCartByPaymentId({ paymentId: payment.id });
-      if (cart.cartState !== 'Ordered') {
-        log.info('Updating cart address after processing the notification', {
-          ctCartId: cart.id,
+      if (isPaymentChargePending) {
+        await this.createSubscriptionOrderFromCart({
+          paymentId: payment.id,
+          charge: invoiceExpanded.charge as Stripe.Charge,
+          paymentIntentId: updateData.pspReference,
           invoiceId: invoiceExpanded.id,
+          paymentState: OrderPaymentState.PAID,
         });
-        const updatedCart = await this.paymentService.updateCartAddress(invoiceExpanded.charge as Stripe.Charge, cart);
-        await this.paymentService.createOrder({ cart: updatedCart, paymentIntentId: updateData.pspReference });
       }
     } catch (e) {
-      log.error(
-        `Error processing Subscription processSubscriptionEventCharged notification: ${JSON.stringify(e, null, 2)}`,
-      );
+      const errorMessage = e instanceof Error ? e.message : JSON.stringify(e);
+      log.error(`Error processing Subscription processSubscriptionEventCharged notification: ${errorMessage}`);
       return;
     }
+  }
+
+  /**
+   * Handles order processing for recurring charge.succeeded events based on config.
+   * @returns True if processing should continue, false if caller should return early
+   */
+  private async handleRecurringChargeOrder(
+    subscription: Stripe.Subscription,
+    invoiceExpanded: StripeInvoiceExpanded,
+    payment: Payment,
+    updateData: StripeEventUpdatePayment,
+  ): Promise<boolean> {
+    const config = getConfig();
+    const shouldCreateNewOrder = config.subscriptionPaymentHandling === 'createOrder';
+    if (shouldCreateNewOrder) {
+      log.info(
+        `Creating new order for subscription charge ${updateData.id} (config: ${config.subscriptionPaymentHandling})`,
+      );
+      updateData.id = await this.handleSubscriptionPaymentCreateNewOrder(
+        subscription,
+        invoiceExpanded,
+        updateData,
+        OrderPaymentState.PAID,
+      );
+      log.info(`New order created successfully for subscription charge ${updateData.id}`);
+    } else {
+      log.info(
+        `Adding payment to existing order for subscription charge ${updateData.id} (config: ${config.subscriptionPaymentHandling})`,
+      );
+      const success = await this.handlePaidSubscriptionPaymentWithCart(
+        invoiceExpanded,
+        subscription,
+        payment,
+        updateData,
+      );
+      if (!success) {
+        return false;
+      }
+    }
+    return true;
   }
 
   public async processSubscriptionEventFailed(event: Stripe.Event): Promise<void> {
@@ -1410,7 +1543,6 @@ export class StripeSubscriptionService {
       const invoiceExpanded = await this.paymentCreationService.getStripeInvoiceExpanded(dataInvoiceId);
 
       const subscription = invoiceExpanded.subscription as Stripe.Subscription;
-      const invoicePaymentIntent = invoiceExpanded.payment_intent as Stripe.PaymentIntent;
       const paymentId = subscription.metadata?.[METADATA_PAYMENT_ID_FIELD];
       if (!paymentId) {
         log.error(
@@ -1426,15 +1558,13 @@ export class StripeSubscriptionService {
         log.error(`Cannot process invoice with ID: ${invoiceExpanded.id}. Missing Payment can be trial days.`);
         return;
       }
-      const failedPaymentIntent = !invoicePaymentIntent
-        ? []
-        : await this.ctPaymentService.findPaymentsByInterfaceId({
-            interfaceId: invoicePaymentIntent.id,
-          });
-      const isPaymentFailed = failedPaymentIntent.length > 0;
-      if (failedPaymentIntent.length > 0) {
-        payment = failedPaymentIntent[0];
-      }
+
+      const { payment: resolvedPayment, isPaymentFailed } = await this.resolveFailedPayment(
+        invoiceExpanded,
+        payment,
+      );
+      payment = resolvedPayment;
+
       const isPaymentChargePending = this.ctPaymentService.hasTransactionInState({
         payment,
         transactionType: PaymentTransactions.CHARGE,
@@ -1446,23 +1576,14 @@ export class StripeSubscriptionService {
         isPaymentChargePending,
         payment,
       );
+
       if (!isPaymentFailed) {
-        const config = getConfig();
-        const shouldCreateNewOrder = config.subscriptionPaymentHandling === 'createOrder';
-        if (shouldCreateNewOrder) {
-          await this.handleSubscriptionPaymentCreateNewOrder(subscription, invoiceExpanded, updateData);
-        } else {
-          const success = await this.handleSubscriptionPaymentWithCart(
-            invoiceExpanded,
-            subscription,
-            payment,
-            updateData,
-          );
-          if (!success) {
-            return;
-          }
+        const shouldContinue = await this.handleFailedEventOrder(subscription, invoiceExpanded, payment, updateData);
+        if (!shouldContinue) {
+          return;
         }
       }
+
       for (const tx of updateData.transactions) {
         const updatedPayment = await this.ctPaymentService.updatePayment({
           ...updateData,
@@ -1478,21 +1599,68 @@ export class StripeSubscriptionService {
         });
       }
 
-      const cart = await this.ctCartService.getCartByPaymentId({ paymentId: payment.id });
-      if (cart.cartState !== 'Ordered') {
-        log.info('Updating cart address after processing the notification', {
-          ctCartId: cart.id,
+      if (isPaymentChargePending || isPaymentFailed) {
+        await this.createSubscriptionOrderFromCart({
+          paymentId: payment.id,
+          charge: invoiceExpanded.charge as Stripe.Charge,
+          paymentIntentId: updateData.pspReference,
           invoiceId: invoiceExpanded.id,
+          paymentState: OrderPaymentState.FAILED,
         });
-        const updatedCart = await this.paymentService.updateCartAddress(invoiceExpanded.charge as Stripe.Charge, cart);
-        await this.paymentService.createOrder({ cart: updatedCart, paymentIntentId: updateData.pspReference });
       }
     } catch (e) {
-      log.error(
-        `Error processing Subscription processSubscriptionEventFailed notification: ${JSON.stringify(e, null, 2)}`,
-      );
+      const errorMessage = e instanceof Error ? e.message : JSON.stringify(e);
+      log.error(`Error processing Subscription processSubscriptionEventFailed notification: ${errorMessage}`);
       return;
     }
+  }
+
+  /**
+   * Resolves the payment from a failed invoice's payment intent, if one exists.
+   */
+  private async resolveFailedPayment(
+    invoiceExpanded: StripeInvoiceExpanded,
+    payment: Payment,
+  ): Promise<{ payment: Payment; isPaymentFailed: boolean }> {
+    const invoicePaymentIntent = invoiceExpanded.payment_intent as Stripe.PaymentIntent;
+    if (!invoicePaymentIntent) {
+      return { payment, isPaymentFailed: false };
+    }
+    const failedPayments = await this.ctPaymentService.findPaymentsByInterfaceId({
+      interfaceId: invoicePaymentIntent.id,
+    });
+    if (failedPayments.length > 0) {
+      return { payment: failedPayments[0], isPaymentFailed: true };
+    }
+    return { payment, isPaymentFailed: false };
+  }
+
+  /**
+   * Handles order processing for failed subscription events based on config.
+   * @returns True if processing should continue, false if caller should return early
+   */
+  private async handleFailedEventOrder(
+    subscription: Stripe.Subscription,
+    invoiceExpanded: StripeInvoiceExpanded,
+    payment: Payment,
+    updateData: StripeEventUpdatePayment,
+  ): Promise<boolean> {
+    const config = getConfig();
+    const shouldCreateNewOrder = config.subscriptionPaymentHandling === 'createOrder';
+    if (shouldCreateNewOrder) {
+      await this.handleSubscriptionPaymentCreateNewOrder(
+        subscription,
+        invoiceExpanded,
+        updateData,
+        OrderPaymentState.FAILED,
+      );
+    } else {
+      const success = await this.handleSubscriptionPaymentWithCart(invoiceExpanded, subscription, payment, updateData);
+      if (!success) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**
@@ -1544,9 +1712,8 @@ export class StripeSubscriptionService {
 
     try {
       const invoiceData = event.data.object as StripeInvoiceExpanded;
-      const subscriptionId = typeof invoiceData.subscription === 'string' 
-        ? invoiceData.subscription 
-        : invoiceData.subscription?.id;
+      const subscriptionId =
+        typeof invoiceData.subscription === 'string' ? invoiceData.subscription : invoiceData.subscription?.id;
 
       if (!subscriptionId) {
         log.warn('Skipping upcoming subscription price synchronization: no subscription ID found in event');
@@ -1828,11 +1995,16 @@ export class StripeSubscriptionService {
 
   /**
    * Handles subscription payment by creating a new order
+   * @param subscription - The Stripe subscription
+   * @param invoiceExpanded - The expanded Stripe invoice
+   * @param updateData - The payment update data
+   * @param paymentState - The payment state for the order
    */
   private async handleSubscriptionPaymentCreateNewOrder(
     subscription: Stripe.Subscription,
     invoiceExpanded: StripeInvoiceExpanded,
     updateData: StripeEventUpdatePayment,
+    paymentState: OrderPaymentState = OrderPaymentState.PAID,
   ): Promise<string> {
     log.info('Creating new order for subscription payment', {
       paymentId: updateData.id,
@@ -1874,6 +2046,7 @@ export class StripeSubscriptionService {
       cart: latestCart,
       paymentIntentId: updateData.pspReference,
       subscriptionId: subscription.id,
+      paymentState,
     });
 
     await this.updateSubscriptionMetadata({

--- a/processor/src/services/types/stripe-payment.type.ts
+++ b/processor/src/services/types/stripe-payment.type.ts
@@ -57,8 +57,14 @@ export enum PaymentStatus {
   INITIAL = 'Initial',
 }
 
+export enum OrderPaymentState {
+  PAID = 'Paid',
+  FAILED = 'Failed',
+}
+
 export interface CreateOrderProps {
   cart: Cart;
   subscriptionId?: string;
   paymentIntentId?: string;
+  paymentState?: OrderPaymentState;
 }

--- a/processor/test/services/commerce-tools/cart-client.spec.ts
+++ b/processor/test/services/commerce-tools/cart-client.spec.ts
@@ -33,7 +33,7 @@ describe('CartClient testing', () => {
 
   describe('createCartFromDraft', () => {
     it('should create the cart from a draft successfully', async () => {
-      const mockCart = mockGetCartResult()
+      const mockCart = mockGetCartResult();
       const executeMock = jest.fn().mockReturnValue(Promise.resolve({ body: mockCart }));
       const client = paymentSDK.ctAPI.client;
       client.carts = jest.fn(() => ({

--- a/processor/test/services/stripe-payment.service.spec.ts
+++ b/processor/test/services/stripe-payment.service.spec.ts
@@ -1567,6 +1567,7 @@ describe('stripe-payment.service', () => {
           pspReference: expect.any(String),
           transactions: expect.any(Array),
         }),
+        'Paid',
       );
 
       expect(spiedUpdatePaymentMock).toHaveBeenCalled();

--- a/processor/test/services/stripe-subscription.service.business-logic.spec.ts
+++ b/processor/test/services/stripe-subscription.service.business-logic.spec.ts
@@ -504,7 +504,6 @@ describe('stripe-subscription.service.business-logic', () => {
           : jest.fn<() => Promise<Stripe.Response<Stripe.Product>>>(),
       } as unknown as Stripe.ProductsResource;
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = await (stripeSubscriptionService as any).getStripeProduct(input);
 
       expect(result).toBe(expectedResult);
@@ -541,7 +540,6 @@ describe('stripe-subscription.service.business-logic', () => {
           .mockResolvedValue(result as Stripe.Response<Stripe.Product>),
       } as unknown as Stripe.ProductsResource;
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const actualResult = await (stripeSubscriptionService as any).createStripeProduct(input);
 
       expect(actualResult).toBe(result.id);
@@ -654,7 +652,6 @@ describe('stripe-subscription.service.business-logic', () => {
           .mockResolvedValue(mockPrice);
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = await (stripeSubscriptionService as any).getCommercetoolsProductPrice('ct_product_123');
 
       expect(result).toEqual(mockPrice);
@@ -707,7 +704,6 @@ describe('stripe-subscription.service.business-logic', () => {
         }),
       } as unknown as Stripe.PricesResource;
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = await (stripeSubscriptionService as any).findStripePriceByProductAndPrice(
         'ct_product_123',
         mockPrice,

--- a/processor/test/services/stripe-subscription.service.order-creation.spec.ts
+++ b/processor/test/services/stripe-subscription.service.order-creation.spec.ts
@@ -1,0 +1,708 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-require-imports */
+jest.mock('stripe', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => {}),
+}));
+
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { StripeSubscriptionService } from '../../src/services/stripe-subscription.service';
+import { CtPaymentCreationService } from '../../src/services/ct-payment-creation.service';
+import { StripePaymentService } from '../../src/services/stripe-payment.service';
+import { paymentSDK } from '../../src/payment-sdk';
+import { SubscriptionEventConverter } from '../../src/services/converters/subscriptionEventConverter';
+import {
+  mockEvent__invoice_paid__simple,
+  mockEvent__charge_succeeded__with_invoice,
+  mockInvoiceExpanded__simple,
+} from '../utils/mock-subscription-data';
+import { mockPayment__subscription_success } from '../utils/mock-payment-results';
+import { DefaultPaymentService } from '@commercetools/connect-payments-sdk/dist/commercetools/services/ct-payment.service';
+import * as Config from '../../src/config/config';
+import Stripe from 'stripe';
+import { METADATA_PAYMENT_ID_FIELD, METADATA_CUSTOMER_ID_FIELD, METADATA_CART_ID_FIELD } from '../../src/constants';
+
+jest.mock('../../src/libs/logger', () => ({
+  log: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+import { log } from '../../src/libs/logger';
+const mockLog = log as jest.Mocked<typeof log>;
+
+jest.mock('../../src/services/commerce-tools/customer-client', () => ({
+  getCustomerById: jest.fn(),
+}));
+
+jest.mock('../../src/services/commerce-tools/cart-client', () => ({
+  createCartFromDraft: jest.fn(),
+  getCartExpanded: jest.fn(),
+  updateCartById: jest.fn(),
+  freezeCart: jest.fn(),
+  isCartFrozen: jest.fn().mockReturnValue(true),
+}));
+
+interface FlexibleConfig {
+  [key: string]: string | number | boolean | Config.PaymentFeatures;
+}
+
+function setupMockConfig(keysAndValues: Record<string, string>) {
+  const mockConfig: FlexibleConfig = {};
+  Object.keys(keysAndValues).forEach((key) => {
+    mockConfig[key] = keysAndValues[key];
+  });
+  jest.spyOn(Config, 'getConfig').mockReturnValue(mockConfig as ReturnType<typeof Config.getConfig>);
+}
+
+describe('Subscription Order Creation Fixes (SUB-ORDER-FIX-05)', () => {
+  const opts = {
+    ctCartService: paymentSDK.ctCartService,
+    ctPaymentService: paymentSDK.ctPaymentService,
+    ctOrderService: paymentSDK.ctOrderService,
+  };
+  const stripeSubscriptionService = new StripeSubscriptionService(opts);
+
+  beforeEach(async () => {
+    jest.setTimeout(10000);
+    jest.resetAllMocks();
+
+    // Restore isCartFrozen default
+    const cartClient = require('../../src/services/commerce-tools/cart-client');
+    cartClient.isCartFrozen.mockReturnValue(true);
+
+    jest.spyOn(SubscriptionEventConverter.prototype, 'convert').mockReturnValue({
+      id: 'payment_123',
+      pspReference: 'in_123',
+      paymentMethod: 'card',
+      pspInteraction: { response: '{}' },
+      transactions: [
+        {
+          amount: { centAmount: 1000, currencyCode: 'USD' },
+          interactionId: 'in_123',
+          state: 'Success',
+          type: 'Charge',
+        },
+      ],
+    });
+
+    Stripe.prototype.subscriptions = {
+      create: jest.fn(),
+      retrieve: jest.fn(),
+      update: jest.fn(),
+      list: jest.fn(),
+      cancel: jest.fn(),
+    } as unknown as Stripe.SubscriptionsResource;
+
+    Stripe.prototype.paymentIntents = {
+      create: jest.fn(),
+      retrieve: jest.fn(),
+      update: jest.fn(),
+    } as unknown as Stripe.PaymentIntentsResource;
+
+    Stripe.prototype.invoices = {
+      create: jest.fn(),
+      retrieve: jest.fn(),
+      finalize: jest.fn(),
+      send: jest.fn(),
+      sendInvoice: jest.fn(),
+      finalizeInvoice: jest.fn(),
+    } as unknown as Stripe.InvoicesResource;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('Race condition handling (invoice.paid vs charge.succeeded)', () => {
+    test('should log info (not error) when version conflict occurs during order creation', async () => {
+      // Simulate: first handler created the order, second handler hits version conflict
+      const mockEvent: Stripe.Event = mockEvent__invoice_paid__simple;
+      const mockInvoiceWithCharge = {
+        ...mockInvoiceExpanded__simple,
+        subscription: {
+          ...mockInvoiceExpanded__simple.subscription,
+          metadata: {
+            [METADATA_PAYMENT_ID_FIELD]: 'ct_payment_123',
+          },
+        },
+        charge: {
+          id: 'ch_123',
+          billing_details: {
+            address: {
+              city: 'Test City',
+              country: 'US',
+              line1: '123 Test St',
+              postal_code: '12345',
+              state: 'CA',
+            },
+          },
+        },
+      };
+
+      jest
+        .spyOn(CtPaymentCreationService.prototype, 'getStripeInvoiceExpanded')
+        .mockResolvedValue(mockInvoiceWithCharge as any);
+      jest.spyOn(DefaultPaymentService.prototype, 'getPayment').mockResolvedValue(mockPayment__subscription_success);
+      jest.spyOn(DefaultPaymentService.prototype, 'findPaymentsByInterfaceId').mockResolvedValue([]);
+      // isPaymentChargePending = true so tail block runs
+      jest.spyOn(DefaultPaymentService.prototype, 'hasTransactionInState').mockReturnValue(true);
+      jest.spyOn(DefaultPaymentService.prototype, 'updatePayment').mockResolvedValue(mockPayment__subscription_success);
+
+      // Mock cart returned by getCartByPaymentId - cart is Active (not yet ordered)
+      jest.spyOn(paymentSDK.ctCartService, 'getCartByPaymentId').mockResolvedValue({
+        id: 'cart_123',
+        cartState: 'Active',
+        version: 1,
+      } as any);
+
+      // Mock updateCartAddress succeeds
+      jest.spyOn(StripePaymentService.prototype, 'updateCartAddress').mockResolvedValue({
+        id: 'cart_123',
+        cartState: 'Active',
+        version: 2,
+      } as any);
+
+      // Mock createOrder throws version conflict (race condition - other handler already created order)
+      jest
+        .spyOn(StripePaymentService.prototype, 'createOrder')
+        .mockRejectedValue(new Error('ConcurrentModification: version mismatch'));
+
+      await stripeSubscriptionService.processSubscriptionEventPaid(mockEvent);
+
+      // Key assertion: version conflict should be logged as info, not error
+      const infoLogCalls = mockLog.info.mock.calls.map((call: any[]) => call[0]);
+      const hasVersionConflictInfoLog = infoLogCalls.some(
+        (msg: string) => typeof msg === 'string' && msg.includes('version conflict'),
+      );
+      expect(hasVersionConflictInfoLog).toBe(true);
+
+      // Verify it was NOT logged as error (the outer catch should not have been reached)
+      const errorLogCalls = mockLog.error.mock.calls.map((call: any[]) => call[0]);
+      const hasVersionConflictErrorLog = errorLogCalls.some(
+        (msg: string) => typeof msg === 'string' && msg.includes('ConcurrentModification'),
+      );
+      expect(hasVersionConflictErrorLog).toBe(false);
+    });
+
+    test('should rethrow non-version-conflict errors from createOrder', async () => {
+      const mockEvent: Stripe.Event = mockEvent__invoice_paid__simple;
+      const mockInvoiceWithCharge = {
+        ...mockInvoiceExpanded__simple,
+        subscription: {
+          ...mockInvoiceExpanded__simple.subscription,
+          metadata: {
+            [METADATA_PAYMENT_ID_FIELD]: 'ct_payment_123',
+          },
+        },
+        charge: {
+          id: 'ch_123',
+          billing_details: {
+            address: {
+              city: 'Test City',
+              country: 'US',
+              line1: '123 Test St',
+              postal_code: '12345',
+              state: 'CA',
+            },
+          },
+        },
+      };
+
+      jest
+        .spyOn(CtPaymentCreationService.prototype, 'getStripeInvoiceExpanded')
+        .mockResolvedValue(mockInvoiceWithCharge as any);
+      jest.spyOn(DefaultPaymentService.prototype, 'getPayment').mockResolvedValue(mockPayment__subscription_success);
+      jest.spyOn(DefaultPaymentService.prototype, 'findPaymentsByInterfaceId').mockResolvedValue([]);
+      jest.spyOn(DefaultPaymentService.prototype, 'hasTransactionInState').mockReturnValue(true);
+      jest.spyOn(DefaultPaymentService.prototype, 'updatePayment').mockResolvedValue(mockPayment__subscription_success);
+
+      jest.spyOn(paymentSDK.ctCartService, 'getCartByPaymentId').mockResolvedValue({
+        id: 'cart_123',
+        cartState: 'Active',
+        version: 1,
+      } as any);
+      jest.spyOn(StripePaymentService.prototype, 'updateCartAddress').mockResolvedValue({
+        id: 'cart_123',
+        cartState: 'Active',
+        version: 2,
+      } as any);
+
+      // Non-version-conflict error
+      jest.spyOn(StripePaymentService.prototype, 'createOrder').mockRejectedValue(new Error('Network error'));
+
+      // The outer catch in processSubscriptionEventPaid will catch it and log as error
+      await stripeSubscriptionService.processSubscriptionEventPaid(mockEvent);
+
+      const errorLogCalls = mockLog.error.mock.calls.map((call: any[]) => call[0]);
+      const hasProcessingErrorLog = errorLogCalls.some(
+        (msg: string) => typeof msg === 'string' && msg.includes('Error processing Subscription'),
+      );
+      expect(hasProcessingErrorLog).toBe(true);
+    });
+
+    test('should skip order creation when cart is already Ordered', async () => {
+      const mockEvent: Stripe.Event = mockEvent__invoice_paid__simple;
+      const mockInvoiceWithCharge = {
+        ...mockInvoiceExpanded__simple,
+        subscription: {
+          ...mockInvoiceExpanded__simple.subscription,
+          metadata: {
+            [METADATA_PAYMENT_ID_FIELD]: 'ct_payment_123',
+          },
+        },
+        charge: {
+          id: 'ch_123',
+          billing_details: {
+            address: {
+              city: 'Test City',
+              country: 'US',
+              line1: '123 Test St',
+              postal_code: '12345',
+              state: 'CA',
+            },
+          },
+        },
+      };
+
+      jest
+        .spyOn(CtPaymentCreationService.prototype, 'getStripeInvoiceExpanded')
+        .mockResolvedValue(mockInvoiceWithCharge as any);
+      jest.spyOn(DefaultPaymentService.prototype, 'getPayment').mockResolvedValue(mockPayment__subscription_success);
+      jest.spyOn(DefaultPaymentService.prototype, 'findPaymentsByInterfaceId').mockResolvedValue([]);
+      jest.spyOn(DefaultPaymentService.prototype, 'hasTransactionInState').mockReturnValue(true);
+      jest.spyOn(DefaultPaymentService.prototype, 'updatePayment').mockResolvedValue(mockPayment__subscription_success);
+
+      // Cart is already ordered (first handler won the race)
+      jest.spyOn(paymentSDK.ctCartService, 'getCartByPaymentId').mockResolvedValue({
+        id: 'cart_123',
+        cartState: 'Ordered',
+        version: 3,
+      } as any);
+
+      const createOrderSpy = jest.spyOn(StripePaymentService.prototype, 'createOrder');
+
+      await stripeSubscriptionService.processSubscriptionEventPaid(mockEvent);
+
+      // createOrder should not have been called since cart was already Ordered
+      expect(createOrderSpy).not.toHaveBeenCalled();
+
+      // Should have logged that the cart was already ordered
+      const infoLogCalls = mockLog.info.mock.calls;
+      const hasAlreadyOrderedLog = infoLogCalls.some(
+        (call: any[]) => typeof call[0] === 'string' && call[0].includes('Cart already ordered'),
+      );
+      expect(hasAlreadyOrderedLog).toBe(true);
+    });
+  });
+
+  describe('processSubscriptionEventFailed creates order with paymentState Failed', () => {
+    test('should pass paymentState Failed to createSubscriptionOrderFromCart for first payment failures', async () => {
+      const mockEvent: Stripe.Event = mockEvent__invoice_paid__simple;
+      const failedPayment = {
+        ...mockPayment__subscription_success,
+        id: 'failed_payment_123',
+        transactions: [{ type: 'Charge', state: 'Failure', amount: { centAmount: 1000, currencyCode: 'USD' } }],
+      };
+      const mockInvoiceWithCharge = {
+        ...mockInvoiceExpanded__simple,
+        subscription: {
+          ...mockInvoiceExpanded__simple.subscription,
+          metadata: {
+            [METADATA_PAYMENT_ID_FIELD]: 'ct_payment_123',
+          },
+        },
+        payment_intent: {
+          id: 'pi_123',
+        },
+        charge: {
+          id: 'ch_123',
+          billing_details: {
+            address: {
+              city: 'Test City',
+              country: 'US',
+              line1: '123 Test St',
+              postal_code: '12345',
+              state: 'CA',
+            },
+          },
+        },
+      };
+
+      jest
+        .spyOn(CtPaymentCreationService.prototype, 'getStripeInvoiceExpanded')
+        .mockResolvedValue(mockInvoiceWithCharge as any);
+      jest.spyOn(DefaultPaymentService.prototype, 'getPayment').mockResolvedValue(mockPayment__subscription_success);
+      // findPaymentsByInterfaceId returns a failed payment => isPaymentFailed = true
+      // This skips config branching but still fires the tail block
+      jest
+        .spyOn(DefaultPaymentService.prototype, 'findPaymentsByInterfaceId')
+        .mockResolvedValue([failedPayment] as any);
+      // isPaymentChargePending = false, but isPaymentFailed = true => tail block still fires
+      jest.spyOn(DefaultPaymentService.prototype, 'hasTransactionInState').mockReturnValue(false);
+      jest.spyOn(DefaultPaymentService.prototype, 'updatePayment').mockResolvedValue(failedPayment as any);
+
+      jest.spyOn(paymentSDK.ctCartService, 'getCartByPaymentId').mockResolvedValue({
+        id: 'cart_123',
+        cartState: 'Active',
+        version: 1,
+      } as any);
+
+      jest.spyOn(StripePaymentService.prototype, 'updateCartAddress').mockResolvedValue({
+        id: 'cart_123',
+        cartState: 'Active',
+        version: 2,
+      } as any);
+
+      const createOrderSpy = jest.spyOn(StripePaymentService.prototype, 'createOrder').mockResolvedValue(undefined);
+
+      await stripeSubscriptionService.processSubscriptionEventFailed(mockEvent);
+
+      // Verify createOrder was called with paymentState 'Failed'
+      expect(createOrderSpy).toHaveBeenCalled();
+      const createOrderCall = createOrderSpy.mock.calls[0][0] as any;
+      expect(createOrderCall.paymentState).toBe('Failed');
+    });
+
+    test('should pass paymentState Failed to handleSubscriptionPaymentCreateNewOrder for recurring failures', async () => {
+      setupMockConfig({
+        subscriptionPaymentHandling: 'createOrder',
+      });
+
+      const mockEvent: Stripe.Event = mockEvent__invoice_paid__simple;
+      const mockInvoiceWithCustomerId = {
+        ...mockInvoiceExpanded__simple,
+        subscription: {
+          ...mockInvoiceExpanded__simple.subscription,
+          metadata: {
+            [METADATA_PAYMENT_ID_FIELD]: 'ct_payment_123',
+          },
+        },
+        subscription_details: {
+          metadata: {
+            [METADATA_CUSTOMER_ID_FIELD]: 'ct_customer_123',
+          },
+        },
+        payment_intent: null,
+        charge: null,
+      };
+
+      jest
+        .spyOn(CtPaymentCreationService.prototype, 'getStripeInvoiceExpanded')
+        .mockResolvedValue(mockInvoiceWithCustomerId as any);
+      jest.spyOn(DefaultPaymentService.prototype, 'getPayment').mockResolvedValue(mockPayment__subscription_success);
+      jest.spyOn(DefaultPaymentService.prototype, 'findPaymentsByInterfaceId').mockResolvedValue([]);
+      // isPaymentFailed = false, isPaymentChargePending = false => config branching runs
+      jest.spyOn(DefaultPaymentService.prototype, 'hasTransactionInState').mockReturnValue(false);
+      jest.spyOn(DefaultPaymentService.prototype, 'updatePayment').mockResolvedValue(mockPayment__subscription_success);
+
+      // Mock handleSubscriptionPaymentCreateNewOrder
+      const handleNewOrderSpy = jest
+        .spyOn(StripeSubscriptionService.prototype as any, 'handleSubscriptionPaymentCreateNewOrder')
+        .mockRejectedValue(new Error('Customer ID not found in invoice metadata'));
+
+      // Cart is already ordered from first payment
+      jest.spyOn(paymentSDK.ctCartService, 'getCartByPaymentId').mockResolvedValue({
+        id: 'cart_123',
+        cartState: 'Ordered',
+        version: 3,
+      } as any);
+
+      await stripeSubscriptionService.processSubscriptionEventFailed(mockEvent);
+
+      // Verify handleSubscriptionPaymentCreateNewOrder was called with paymentState 'Failed'
+      expect(handleNewOrderSpy).toHaveBeenCalled();
+      const lastArg = handleNewOrderSpy.mock.calls[0][3];
+      expect(lastArg).toBe('Failed');
+    });
+  });
+
+  describe('processSubscriptionEventCharged respects subscriptionPaymentHandling config', () => {
+    const mockInvoiceWithConfig = {
+      ...mockInvoiceExpanded__simple,
+      subscription: {
+        ...mockInvoiceExpanded__simple.subscription,
+        metadata: {
+          [METADATA_PAYMENT_ID_FIELD]: 'ct_payment_123',
+        },
+      },
+      subscription_details: {
+        metadata: {
+          [METADATA_CART_ID_FIELD]: 'cart_123',
+          [METADATA_CUSTOMER_ID_FIELD]: 'ct_customer_123',
+        },
+      },
+      charge: {
+        id: 'ch_123',
+        billing_details: {
+          address: {
+            city: 'Test City',
+            country: 'US',
+            line1: '123 Test St',
+            postal_code: '12345',
+            state: 'CA',
+          },
+        },
+      },
+    };
+
+    test('should call handleSubscriptionPaymentCreateNewOrder when config is createOrder and not charge pending', async () => {
+      setupMockConfig({
+        subscriptionPaymentHandling: 'createOrder',
+      });
+
+      const mockEvent: Stripe.Event = mockEvent__charge_succeeded__with_invoice;
+
+      jest
+        .spyOn(CtPaymentCreationService.prototype, 'getStripeInvoiceExpanded')
+        .mockResolvedValue(mockInvoiceWithConfig as any);
+      jest.spyOn(DefaultPaymentService.prototype, 'getPayment').mockResolvedValue(mockPayment__subscription_success);
+      // isPaymentChargePending = false => config branching runs
+      jest.spyOn(DefaultPaymentService.prototype, 'hasTransactionInState').mockReturnValue(false);
+      jest.spyOn(DefaultPaymentService.prototype, 'updatePayment').mockResolvedValue(mockPayment__subscription_success);
+
+      const handleNewOrderSpy = jest
+        .spyOn(StripeSubscriptionService.prototype as any, 'handleSubscriptionPaymentCreateNewOrder')
+        .mockResolvedValue('new_payment_ref');
+
+      // Tail block will also run, mock cart as Ordered so it skips
+      jest.spyOn(paymentSDK.ctCartService, 'getCartByPaymentId').mockResolvedValue({
+        id: 'cart_123',
+        cartState: 'Ordered',
+        version: 3,
+      } as any);
+
+      await stripeSubscriptionService.processSubscriptionEventCharged(mockEvent);
+
+      expect(handleNewOrderSpy).toHaveBeenCalled();
+      // Verify paymentState 'Paid' is passed
+      const paymentStateArg = handleNewOrderSpy.mock.calls[0][3];
+      expect(paymentStateArg).toBe('Paid');
+    });
+
+    test('should call handlePaidSubscriptionPaymentWithCart when config is addPaymentToOrder and not charge pending', async () => {
+      setupMockConfig({
+        subscriptionPaymentHandling: 'addPaymentToOrder',
+      });
+
+      const mockEvent: Stripe.Event = mockEvent__charge_succeeded__with_invoice;
+
+      const mockInvoiceForAddPayment = {
+        ...mockInvoiceWithConfig,
+        amount_paid: 1000,
+        currency: 'usd',
+      };
+
+      jest
+        .spyOn(CtPaymentCreationService.prototype, 'getStripeInvoiceExpanded')
+        .mockResolvedValue(mockInvoiceForAddPayment as any);
+      jest.spyOn(DefaultPaymentService.prototype, 'getPayment').mockResolvedValue(mockPayment__subscription_success);
+      // isPaymentChargePending = false => config branching runs
+      jest.spyOn(DefaultPaymentService.prototype, 'hasTransactionInState').mockReturnValue(false);
+      jest.spyOn(DefaultPaymentService.prototype, 'updatePayment').mockResolvedValue(mockPayment__subscription_success);
+
+      // Mock the addPaymentToOrder path
+      jest.spyOn(paymentSDK.ctCartService, 'getCart').mockResolvedValue({
+        id: 'cart_123',
+        lineItems: [],
+        totalPrice: { centAmount: 1000, currencyCode: 'USD', fractionDigits: 2 },
+      } as any);
+      jest.spyOn(CtPaymentCreationService.prototype, 'handleCtPaymentSubscription').mockResolvedValue('new_pay_123');
+      jest.spyOn(StripePaymentService.prototype, 'updateCartAddress').mockResolvedValue({
+        id: 'cart_123',
+        version: 2,
+      } as any);
+      jest.spyOn(StripePaymentService.prototype, 'createOrder').mockResolvedValue(undefined);
+      jest.spyOn(StripePaymentService.prototype, 'addPaymentToOrder').mockResolvedValue(undefined);
+
+      // Tail block mock
+      jest.spyOn(paymentSDK.ctCartService, 'getCartByPaymentId').mockResolvedValue({
+        id: 'cart_123',
+        cartState: 'Ordered',
+        version: 3,
+      } as any);
+
+      const handleNewOrderSpy = jest
+        .spyOn(StripeSubscriptionService.prototype as any, 'handleSubscriptionPaymentCreateNewOrder')
+        .mockResolvedValue('new_payment_ref');
+
+      await stripeSubscriptionService.processSubscriptionEventCharged(mockEvent);
+
+      // handleSubscriptionPaymentCreateNewOrder should NOT be called
+      expect(handleNewOrderSpy).not.toHaveBeenCalled();
+      // handlePaidSubscriptionPaymentWithCart uses getCart to get the cart by ID
+      expect(paymentSDK.ctCartService.getCart).toHaveBeenCalledWith({ id: 'cart_123' });
+    });
+
+    test('should skip config branching when isPaymentChargePending is true (first payment)', async () => {
+      setupMockConfig({
+        subscriptionPaymentHandling: 'createOrder',
+      });
+
+      const mockEvent: Stripe.Event = mockEvent__charge_succeeded__with_invoice;
+
+      jest
+        .spyOn(CtPaymentCreationService.prototype, 'getStripeInvoiceExpanded')
+        .mockResolvedValue(mockInvoiceWithConfig as any);
+      jest.spyOn(DefaultPaymentService.prototype, 'getPayment').mockResolvedValue(mockPayment__subscription_success);
+      // isPaymentChargePending = true => skip config branching, run tail block
+      jest.spyOn(DefaultPaymentService.prototype, 'hasTransactionInState').mockReturnValue(true);
+      jest.spyOn(DefaultPaymentService.prototype, 'updatePayment').mockResolvedValue(mockPayment__subscription_success);
+
+      const handleNewOrderSpy = jest
+        .spyOn(StripeSubscriptionService.prototype as any, 'handleSubscriptionPaymentCreateNewOrder')
+        .mockResolvedValue('new_payment_ref');
+
+      // Tail block runs for first payment
+      jest.spyOn(paymentSDK.ctCartService, 'getCartByPaymentId').mockResolvedValue({
+        id: 'cart_123',
+        cartState: 'Active',
+        version: 1,
+      } as any);
+      jest.spyOn(StripePaymentService.prototype, 'updateCartAddress').mockResolvedValue({
+        id: 'cart_123',
+        version: 2,
+      } as any);
+      jest.spyOn(StripePaymentService.prototype, 'createOrder').mockResolvedValue(undefined);
+
+      await stripeSubscriptionService.processSubscriptionEventCharged(mockEvent);
+
+      // Config branching should NOT have run (it's first payment)
+      expect(handleNewOrderSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Unfrozen cart warning in createSubscriptionOrderFromCart', () => {
+    test('should log warning when cart is not frozen', async () => {
+      const cartClient = require('../../src/services/commerce-tools/cart-client');
+      cartClient.isCartFrozen.mockReturnValue(false);
+
+      const mockEvent: Stripe.Event = mockEvent__invoice_paid__simple;
+      const mockInvoiceWithCharge = {
+        ...mockInvoiceExpanded__simple,
+        subscription: {
+          ...mockInvoiceExpanded__simple.subscription,
+          metadata: {
+            [METADATA_PAYMENT_ID_FIELD]: 'ct_payment_123',
+          },
+        },
+        charge: {
+          id: 'ch_123',
+          billing_details: {
+            address: {
+              city: 'Test City',
+              country: 'US',
+              line1: '123 Test St',
+              postal_code: '12345',
+              state: 'CA',
+            },
+          },
+        },
+      };
+
+      jest
+        .spyOn(CtPaymentCreationService.prototype, 'getStripeInvoiceExpanded')
+        .mockResolvedValue(mockInvoiceWithCharge as any);
+      jest.spyOn(DefaultPaymentService.prototype, 'getPayment').mockResolvedValue(mockPayment__subscription_success);
+      jest.spyOn(DefaultPaymentService.prototype, 'findPaymentsByInterfaceId').mockResolvedValue([]);
+      jest.spyOn(DefaultPaymentService.prototype, 'hasTransactionInState').mockReturnValue(true);
+      jest.spyOn(DefaultPaymentService.prototype, 'updatePayment').mockResolvedValue(mockPayment__subscription_success);
+
+      jest.spyOn(paymentSDK.ctCartService, 'getCartByPaymentId').mockResolvedValue({
+        id: 'cart_123',
+        cartState: 'Active',
+        version: 1,
+      } as any);
+      jest.spyOn(StripePaymentService.prototype, 'updateCartAddress').mockResolvedValue({
+        id: 'cart_123',
+        cartState: 'Active',
+        version: 2,
+      } as any);
+      jest.spyOn(StripePaymentService.prototype, 'createOrder').mockResolvedValue(undefined);
+
+      await stripeSubscriptionService.processSubscriptionEventPaid(mockEvent);
+
+      // Should have warned about unfrozen cart
+      const warnCalls = mockLog.warn.mock.calls;
+      const hasUnfrozenWarning = warnCalls.some(
+        (call: any[]) => typeof call[0] === 'string' && call[0].includes('unfrozen cart'),
+      );
+      expect(hasUnfrozenWarning).toBe(true);
+    });
+  });
+
+  describe('processSubscriptionEventPaid tail block guard', () => {
+    test('should NOT run tail block when isPaymentChargePending is false and isPaymentFailed is false (recurring payment)', async () => {
+      setupMockConfig({
+        subscriptionPaymentHandling: 'addPaymentToOrder',
+      });
+
+      const mockEvent: Stripe.Event = mockEvent__invoice_paid__simple;
+      const mockInvoiceWithCartId = {
+        ...mockInvoiceExpanded__simple,
+        subscription: {
+          ...mockInvoiceExpanded__simple.subscription,
+          metadata: {
+            [METADATA_PAYMENT_ID_FIELD]: 'ct_payment_123',
+          },
+        },
+        subscription_details: {
+          metadata: {
+            [METADATA_CART_ID_FIELD]: 'cart_123',
+          },
+        },
+        amount_paid: 1000,
+        currency: 'usd',
+        charge: {
+          id: 'ch_123',
+          billing_details: {
+            address: {
+              city: 'Test City',
+              country: 'US',
+              line1: '123 Test St',
+              postal_code: '12345',
+              state: 'CA',
+            },
+          },
+        },
+      };
+
+      jest
+        .spyOn(CtPaymentCreationService.prototype, 'getStripeInvoiceExpanded')
+        .mockResolvedValue(mockInvoiceWithCartId as any);
+      jest.spyOn(DefaultPaymentService.prototype, 'getPayment').mockResolvedValue(mockPayment__subscription_success);
+      jest.spyOn(DefaultPaymentService.prototype, 'findPaymentsByInterfaceId').mockResolvedValue([]);
+      // Both false => recurring payment, config branching handles it
+      jest.spyOn(DefaultPaymentService.prototype, 'hasTransactionInState').mockReturnValue(false);
+      jest.spyOn(DefaultPaymentService.prototype, 'updatePayment').mockResolvedValue(mockPayment__subscription_success);
+
+      jest.spyOn(paymentSDK.ctCartService, 'getCart').mockResolvedValue({
+        id: 'cart_123',
+        lineItems: [],
+        totalPrice: { centAmount: 1000, currencyCode: 'USD', fractionDigits: 2 },
+      } as any);
+      jest.spyOn(CtPaymentCreationService.prototype, 'handleCtPaymentSubscription').mockResolvedValue('new_pay_123');
+      jest.spyOn(StripePaymentService.prototype, 'updateCartAddress').mockResolvedValue({
+        id: 'cart_123',
+        version: 2,
+      } as any);
+      jest.spyOn(StripePaymentService.prototype, 'createOrder').mockResolvedValue(undefined);
+      jest.spyOn(StripePaymentService.prototype, 'addPaymentToOrder').mockResolvedValue(undefined);
+
+      // The tail block uses getCartByPaymentId - if it runs, it would call this
+      const getCartByPaymentIdSpy = jest.spyOn(paymentSDK.ctCartService, 'getCartByPaymentId').mockResolvedValue({
+        id: 'cart_123',
+        cartState: 'Ordered',
+        version: 3,
+      } as any);
+
+      await stripeSubscriptionService.processSubscriptionEventPaid(mockEvent);
+
+      // Tail block should NOT have run because isPaymentChargePending=false and isPaymentFailed=false
+      expect(getCartByPaymentIdSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/processor/test/services/stripe-subscription.service.order-creation.spec.ts
+++ b/processor/test/services/stripe-subscription.service.order-creation.spec.ts
@@ -5,7 +5,7 @@ jest.mock('stripe', () => ({
   default: jest.fn().mockImplementation(() => {}),
 }));
 
-import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
 import { StripeSubscriptionService } from '../../src/services/stripe-subscription.service';
 import { CtPaymentCreationService } from '../../src/services/ct-payment-creation.service';
 import { StripePaymentService } from '../../src/services/stripe-payment.service';

--- a/processor/test/services/stripe-subscription.service.payment.spec.ts
+++ b/processor/test/services/stripe-subscription.service.payment.spec.ts
@@ -25,6 +25,8 @@ import * as Config from '../../src/config/config';
 import Stripe from 'stripe';
 import { Payment } from '@commercetools/connect-payments-sdk';
 import { METADATA_PAYMENT_ID_FIELD, METADATA_CUSTOMER_ID_FIELD, METADATA_CART_ID_FIELD } from '../../src/constants';
+import * as Logger from '../../src/libs/logger/index';
+import { mockEvent__charge_succeeded__with_invoice } from '../utils/mock-subscription-data';
 
 jest.mock('../../src/libs/logger');
 jest.mock('../../src/services/commerce-tools/customer-client', () => ({
@@ -601,6 +603,273 @@ describe('stripe-subscription.service.payment', () => {
       });
       expect(result).toBeDefined();
       expect(getPaymentMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('race condition handling in createSubscriptionOrderFromCart', () => {
+    test('should log info (not error) when second handler hits version conflict during order creation', async () => {
+      const mockEvent: Stripe.Event = mockEvent__invoice_paid__simple;
+
+      const mockInvoiceWithCharge = {
+        ...mockInvoiceExpanded__simple,
+        subscription: {
+          ...mockInvoiceExpanded__simple.subscription,
+          metadata: {
+            [METADATA_PAYMENT_ID_FIELD]: 'ct_payment_123',
+          },
+        },
+        charge: {
+          id: 'ch_123',
+          billing_details: {
+            address: {
+              city: 'San Francisco',
+              country: 'US',
+              line1: '123 Test St',
+              postal_code: '94105',
+              state: 'CA',
+            },
+          },
+        },
+      };
+
+      jest
+        .spyOn(CtPaymentCreationService.prototype, 'getStripeInvoiceExpanded')
+        .mockResolvedValue(mockInvoiceWithCharge as any);
+      jest.spyOn(DefaultPaymentService.prototype, 'getPayment').mockResolvedValue(mockPayment__subscription_success);
+      jest.spyOn(DefaultPaymentService.prototype, 'findPaymentsByInterfaceId').mockResolvedValue([]);
+      // isPaymentChargePending = true so tail block runs
+      jest.spyOn(DefaultPaymentService.prototype, 'hasTransactionInState').mockReturnValue(true);
+      jest.spyOn(DefaultPaymentService.prototype, 'updatePayment').mockResolvedValue(mockPayment__subscription_success);
+
+      // Cart is Active (not yet ordered)
+      jest.spyOn(paymentSDK.ctCartService, 'getCartByPaymentId').mockResolvedValue({
+        cartState: 'Active',
+        id: 'cart_123',
+        frozen: true,
+      } as any);
+
+      jest.spyOn(StripePaymentService.prototype, 'updateCartAddress').mockResolvedValue({
+        id: 'cart_123',
+        cartState: 'Active',
+      } as any);
+
+      // Simulate version conflict (race condition - other handler already created the order)
+      jest
+        .spyOn(StripePaymentService.prototype, 'createOrder')
+        .mockRejectedValue(new Error('ConcurrentModification: Object version does not match'));
+
+      await stripeSubscriptionService.processSubscriptionEventPaid(mockEvent);
+
+      // Should log info about the race condition, NOT error
+      expect(Logger.log.info).toHaveBeenCalledWith(
+        'Subscription order creation skipped due to version conflict (likely race condition with another handler)',
+        expect.objectContaining({
+          ctCartId: 'cart_123',
+        }),
+      );
+      // The outer catch should NOT be reached (version conflict is handled gracefully)
+      expect(Logger.log.error).not.toHaveBeenCalledWith(
+        expect.stringContaining('Error processing Subscription processSubscriptionEventPaid'),
+      );
+    });
+  });
+
+  describe('processSubscriptionEventFailed with paymentState Failed', () => {
+    test('should create order with paymentState Failed when first payment fails (isPaymentFailed)', async () => {
+      const mockEvent: Stripe.Event = mockEvent__invoice_paid__simple;
+
+      const failedPayment = {
+        ...mockPayment__subscription_success,
+        id: 'failedPaymentId',
+        transactions: [
+          {
+            type: 'Charge',
+            state: 'Failure',
+            amount: { centAmount: 1000, currencyCode: 'USD' },
+          },
+        ],
+      };
+
+      const mockInvoiceWithCharge = {
+        ...mockInvoiceExpanded__simple,
+        subscription: {
+          ...mockInvoiceExpanded__simple.subscription,
+          metadata: {
+            [METADATA_PAYMENT_ID_FIELD]: 'ct_payment_123',
+          },
+        },
+        charge: {
+          id: 'ch_123',
+          billing_details: {
+            address: {
+              city: 'San Francisco',
+              country: 'US',
+              line1: '123 Test St',
+              postal_code: '94105',
+              state: 'CA',
+            },
+          },
+        },
+      };
+
+      jest
+        .spyOn(CtPaymentCreationService.prototype, 'getStripeInvoiceExpanded')
+        .mockResolvedValue(mockInvoiceWithCharge as any);
+      jest.spyOn(DefaultPaymentService.prototype, 'getPayment').mockResolvedValue(mockPayment__subscription_success);
+      // Return a failed payment so isPaymentFailed = true, which skips config branching
+      // and the tail block guard (isPaymentChargePending || isPaymentFailed) is satisfied
+      jest
+        .spyOn(DefaultPaymentService.prototype, 'findPaymentsByInterfaceId')
+        .mockResolvedValue([failedPayment as any]);
+      jest.spyOn(DefaultPaymentService.prototype, 'hasTransactionInState').mockReturnValue(false);
+      jest.spyOn(DefaultPaymentService.prototype, 'updatePayment').mockResolvedValue(failedPayment as any);
+
+      jest.spyOn(paymentSDK.ctCartService, 'getCartByPaymentId').mockResolvedValue({
+        cartState: 'Active',
+        id: 'cart_123',
+        frozen: true,
+      } as any);
+
+      jest.spyOn(StripePaymentService.prototype, 'updateCartAddress').mockResolvedValue({
+        id: 'cart_123',
+        cartState: 'Active',
+      } as any);
+
+      const spiedCreateOrder = jest.spyOn(StripePaymentService.prototype, 'createOrder').mockResolvedValue(undefined);
+
+      await stripeSubscriptionService.processSubscriptionEventFailed(mockEvent);
+
+      // Verify createOrder is called with paymentState 'Failed'
+      expect(spiedCreateOrder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          paymentState: 'Failed',
+        }),
+      );
+    });
+  });
+
+  describe('processSubscriptionEventCharged config branching', () => {
+    test('should respect subscriptionPaymentHandling config when processing charge.succeeded for recurring payment', async () => {
+      setupMockConfig({
+        subscriptionPaymentHandling: 'createOrder',
+      });
+
+      const mockEvent: Stripe.Event = mockEvent__charge_succeeded__with_invoice;
+
+      const mockInvoiceWithCustomer = {
+        ...mockInvoiceExpanded__simple,
+        subscription: {
+          ...mockInvoiceExpanded__simple.subscription,
+          metadata: {
+            [METADATA_PAYMENT_ID_FIELD]: 'ct_payment_123',
+          },
+        },
+        subscription_details: {
+          metadata: {
+            [METADATA_CUSTOMER_ID_FIELD]: 'ct_customer_123',
+          },
+        },
+        charge: {
+          id: 'ch_123',
+          billing_details: {
+            address: {
+              city: 'San Francisco',
+              country: 'US',
+              line1: '123 Test St',
+              postal_code: '94105',
+              state: 'CA',
+            },
+          },
+        },
+      };
+
+      jest
+        .spyOn(CtPaymentCreationService.prototype, 'getStripeInvoiceExpanded')
+        .mockResolvedValue(mockInvoiceWithCustomer as any);
+      jest.spyOn(DefaultPaymentService.prototype, 'getPayment').mockResolvedValue(mockPayment__subscription_success);
+      // isPaymentChargePending = false (recurring payment, triggers config branching)
+      jest.spyOn(DefaultPaymentService.prototype, 'hasTransactionInState').mockReturnValue(false);
+      jest.spyOn(DefaultPaymentService.prototype, 'updatePayment').mockResolvedValue(mockPayment__subscription_success);
+
+      // Mock getOrderByPaymentId for handleSubscriptionPaymentCreateNewOrder
+      jest.spyOn(paymentSDK.ctOrderService, 'getOrderByPaymentId').mockRejectedValue(new Error('Order not found'));
+
+      // Mock getCartByPaymentId for the tail block
+      jest.spyOn(paymentSDK.ctCartService, 'getCartByPaymentId').mockResolvedValue({
+        cartState: 'Ordered',
+        id: 'cart_123',
+      } as any);
+
+      await stripeSubscriptionService.processSubscriptionEventCharged(mockEvent);
+
+      // Should check config and attempt to create new order (createOrder path)
+      expect(paymentSDK.ctOrderService.getOrderByPaymentId).toHaveBeenCalledWith({ paymentId: 'payment_123' });
+    });
+
+    test('should use addPaymentToOrder path when config is not createOrder for charge.succeeded', async () => {
+      setupMockConfig({
+        subscriptionPaymentHandling: 'addPaymentToOrder',
+      });
+
+      const mockEvent: Stripe.Event = mockEvent__charge_succeeded__with_invoice;
+
+      const mockInvoiceWithCart = {
+        ...mockInvoiceExpanded__simple,
+        subscription: {
+          ...mockInvoiceExpanded__simple.subscription,
+          metadata: {
+            [METADATA_PAYMENT_ID_FIELD]: 'ct_payment_123',
+          },
+        },
+        subscription_details: {
+          metadata: {
+            [METADATA_CART_ID_FIELD]: 'cart_original_123',
+          },
+        },
+        charge: {
+          id: 'ch_123',
+          billing_details: {
+            address: {
+              city: 'San Francisco',
+              country: 'US',
+              line1: '123 Test St',
+              postal_code: '94105',
+              state: 'CA',
+            },
+          },
+        },
+      };
+
+      const mockCart = {
+        id: 'cart_original_123',
+        lineItems: [],
+        totalPrice: { centAmount: 1000, currencyCode: 'USD', fractionDigits: 2 },
+      };
+
+      jest
+        .spyOn(CtPaymentCreationService.prototype, 'getStripeInvoiceExpanded')
+        .mockResolvedValue(mockInvoiceWithCart as any);
+      jest.spyOn(DefaultPaymentService.prototype, 'getPayment').mockResolvedValue(mockPayment__subscription_success);
+      // isPaymentChargePending = false (recurring payment)
+      jest.spyOn(DefaultPaymentService.prototype, 'hasTransactionInState').mockReturnValue(false);
+      jest.spyOn(DefaultPaymentService.prototype, 'updatePayment').mockResolvedValue(mockPayment__subscription_success);
+
+      jest.spyOn(paymentSDK.ctCartService, 'getCart').mockResolvedValue(mockCart as any);
+      jest.spyOn(CtPaymentCreationService.prototype, 'handleCtPaymentCreation').mockResolvedValue('new_payment_123');
+      jest.spyOn(StripePaymentService.prototype, 'updateCartAddress').mockResolvedValue(mockCart as any);
+      jest.spyOn(StripePaymentService.prototype, 'createOrder').mockResolvedValue(undefined);
+      jest.spyOn(StripePaymentService.prototype, 'addPaymentToOrder').mockResolvedValue(undefined);
+
+      // Mock getCartByPaymentId for the tail block
+      jest.spyOn(paymentSDK.ctCartService, 'getCartByPaymentId').mockResolvedValue({
+        cartState: 'Ordered',
+        id: 'cart_123',
+      } as any);
+
+      await stripeSubscriptionService.processSubscriptionEventCharged(mockEvent);
+
+      // Should use addPaymentToOrder path
+      expect(paymentSDK.ctCartService.getCart).toHaveBeenCalledWith({ id: 'cart_original_123' });
     });
   });
 });


### PR DESCRIPTION
Subscription order creation:
- Introduce OrderPaymentState enum (Paid/Failed) and thread it through
  createOrderFromCart, StripePaymentService.createOrder, and
  handleSubscriptionPaymentCreateNewOrder so failed events produce
  orders with paymentState: Failed instead of Paid
- Extract createSubscriptionOrderFromCart shared helper to replace
  duplicated address-update + order-creation tail blocks across
  processSubscriptionEventPaid, processSubscriptionEventCharged,
  and processSubscriptionEventFailed
- Handle invoice.paid / charge.succeeded race conditions by catching
  ConcurrentModification/409 version conflicts and skipping gracefully
- Add config-based branching for recurring charge.succeeded events via
  handleRecurringChargeOrder, consistent with how invoice.paid worked
- Guard tail blocks with cart.cartState === 'Ordered' check to prevent
  duplicate order creation
- Warn when processing a subscription order for an unfrozen cart

Refactor:
- Extract hasCompleteAddress, unfreezeCartIfNeeded, and refreezeCart
  private methods from updateCartAddress
- Extract handleRecurringChargeOrder, handleFailedEventOrder, and
  resolveFailedPayment to reduce cognitive complexity in subscription
  event handlers
- Fix log template string bug (updatedPayment.version was not interpolated)
- Remove unused Stripe import from ct-payment-creation.service.ts

Security:
- Pin brace-expansion to 2.0.3 via overrides in processor to fix
  DoS vulnerability (https://github.com/advisories/GHSA-f886-m6hf-6m8v)
- Bump vite to ^7.3.2 in enabler

Tests:
- Add stripe-subscription.service.payment.spec.ts covering race conditions,
  cart state validation, payment state propagation, config-based branching,
  and unfrozen cart warnings

Docs:
- Update CHANGELOG.md with full entry for this release