### PR TITLE
fix(customer): prevent literal "undefined undefined" Stripe Customer name

### DIFF
--- a/processor/src/services/stripe-customer.service.ts
+++ b/processor/src/services/stripe-customer.service.ts
@@ -139,7 +139,7 @@ export class StripeCustomerService {
     const email = cart.customerEmail || customer.email || cart.shippingAddress?.email;
     return await stripe.customers.create({
       email,
-      name: `${customer.firstName} ${customer.lastName}`.trim() || shippingAddress?.name,
+      name: `${customer.firstName ?? ''} ${customer.lastName ?? ''}`.trim() || shippingAddress?.name,
       phone: shippingAddress?.phone,
       address: shippingAddress?.address,
       metadata: {

--- a/processor/test/services/stripe-customer.service.spec.ts
+++ b/processor/test/services/stripe-customer.service.spec.ts
@@ -403,6 +403,86 @@ describe('stripe-customer.service', () => {
       expect(result).toBeDefined();
       expect(mockCreateCustomer).toHaveBeenCalled();
     });
+
+    test('should fall back to shippingAddress name when CT customer firstName and lastName are undefined', async () => {
+      const mockCtCustomer: Customer = {
+        ...mockCtCustomerData,
+        firstName: undefined,
+        lastName: undefined,
+      };
+      const mockCreateCustomer = jest
+        .spyOn(Stripe.prototype.customers, 'create')
+        .mockReturnValue(Promise.resolve(mockCustomerData));
+
+      // mockGetCartResult provides shippingAddress.firstName: 'John', shippingAddress.lastName: 'Smith'
+      await stripeCustomerService.createStripeCustomer(mockGetCartResult(), mockCtCustomer);
+
+      expect(mockCreateCustomer).toHaveBeenCalledWith(expect.objectContaining({ name: 'John Smith' }));
+      expect(mockCreateCustomer).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: expect.stringContaining('undefined') }),
+      );
+    });
+
+    test('should fall back to shippingAddress name when CT customer has empty firstName and lastName', async () => {
+      const mockCtCustomer: Customer = {
+        ...mockCtCustomerData,
+        firstName: '',
+        lastName: '',
+      };
+      const mockCreateCustomer = jest
+        .spyOn(Stripe.prototype.customers, 'create')
+        .mockReturnValue(Promise.resolve(mockCustomerData));
+
+      await stripeCustomerService.createStripeCustomer(mockGetCartResult(), mockCtCustomer);
+
+      expect(mockCreateCustomer).toHaveBeenCalledWith(expect.objectContaining({ name: 'John Smith' }));
+    });
+
+    test('should use only the populated name field when CT customer has firstName but no lastName', async () => {
+      const mockCtCustomer: Customer = {
+        ...mockCtCustomerData,
+        firstName: 'Jane',
+        lastName: undefined,
+      };
+      const mockCreateCustomer = jest
+        .spyOn(Stripe.prototype.customers, 'create')
+        .mockReturnValue(Promise.resolve(mockCustomerData));
+
+      await stripeCustomerService.createStripeCustomer(mockGetCartResult(), mockCtCustomer);
+
+      expect(mockCreateCustomer).toHaveBeenCalledWith(expect.objectContaining({ name: 'Jane' }));
+    });
+
+    test('should leave name undefined when both CT customer and addresses have no name fields', async () => {
+      const cart = mockGetCartResult();
+      const mockCart: Cart = {
+        ...cart,
+        shippingAddress: undefined,
+      };
+      const mockCtCustomer: Customer = {
+        ...mockCtCustomerData,
+        firstName: undefined,
+        lastName: undefined,
+        addresses: [],
+      };
+      const mockCreateCustomer = jest
+        .spyOn(Stripe.prototype.customers, 'create')
+        .mockReturnValue(Promise.resolve(mockCustomerData));
+
+      await stripeCustomerService.createStripeCustomer(mockCart, mockCtCustomer);
+
+      expect(mockCreateCustomer).toHaveBeenCalledWith(expect.objectContaining({ name: undefined }));
+    });
+
+    test('should use CT customer name when firstName and lastName are populated', async () => {
+      const mockCreateCustomer = jest
+        .spyOn(Stripe.prototype.customers, 'create')
+        .mockReturnValue(Promise.resolve(mockCustomerData));
+
+      await stripeCustomerService.createStripeCustomer(mockGetCartResult(), mockCtCustomerData);
+
+      expect(mockCreateCustomer).toHaveBeenCalledWith(expect.objectContaining({ name: 'John Smith' }));
+    });
   });
 
   describe('method saveStripeCustomerId', () => {


### PR DESCRIPTION
## Summary

When a Commercetools Customer record has no `firstName` or `lastName`, the connector creates a Stripe Customer with `name: "undefined undefined"` (the literal string). The intended `shippingAddress?.name` fallback never fires, because the string concatenation produces a truthy value.

The result is visible in the Stripe Dashboard: every logged-in transaction for a CT Customer without name fields shows up under a Customer named literally `"undefined undefined"`.

## Root cause

In `processor/src/services/stripe-customer.service.ts`:

```ts
name: `${customer.firstName} ${customer.lastName}`.trim() || shippingAddress?.name,
```

The Commercetools Customer API omits unset optional fields entirely from the response payload — so `customer.firstName` and `customer.lastName` are `undefined`, not `""`.

In JavaScript, `` `${undefined} ${undefined}` `` produces the literal string `"undefined undefined"` (not an empty string). `.trim()` returns the same string unchanged. That string is truthy, so the `|| shippingAddress?.name` fallback short-circuits — even though `shippingAddress` does contain a usable name derived from the cart's billing/shipping address.

## Fix

Substitute empty strings for `undefined` fields with `?? ''` before interpolation. After trimming, the result is `""` when both fields are missing — falsy — so the existing fallback takes effect.

```ts
name: `${customer.firstName ?? ''} ${customer.lastName ?? ''}`.trim() || shippingAddress?.name,
```

This keeps the existing structure (template literal + `.trim()` + `||` fallback) and matches the file's existing nullish-coalescing style used in `getField` and `getBillingAddress`.

## Behavior

| `customer.firstName` | `customer.lastName` | Before | After |
|---|---|---|---|
| `undefined` | `undefined` | `"undefined undefined"` (bug) | falls back to `shippingAddress.name` |
| `""` | `""` | falls back to `shippingAddress.name` | falls back to `shippingAddress.name` (unchanged) |
| `"John"` | `undefined` | `"John undefined"` (bug) | `"John"` |
| `undefined` | `"Smith"` | `"undefined Smith"` (bug) | `"Smith"` |
| `"John"` | `"Smith"` | `"John Smith"` | `"John Smith"` (unchanged) |

## Tests

Five test cases in `processor/test/services/stripe-customer.service.spec.ts`:

1. CT customer with `undefined` firstName/lastName → falls back to `shippingAddress.name`, with a negative assertion that the name never contains the substring `"undefined"`.
2. CT customer with empty-string firstName/lastName → falls back to `shippingAddress.name`.
3. CT customer with `firstName: "Jane", lastName: undefined` → uses `"Jane"`.
4. CT customer with no name and no shipping/customer addresses → name remains `undefined` (graceful degradation).
5. CT customer with both names populated → uses the CT customer name (regression guard).

## Verification

- Full processor test suite passes locally — `Test Suites: 39 passed, Tests: 565 passed`.
- Prettier and ESLint pass on the two changed files.

## Notes

- No schema changes, no new env vars, no API surface changes.
- Only `createStripeCustomer` is affected — `customers.create` has exactly one call site in the codebase.